### PR TITLE
update mangadex limits

### DIFF
--- a/web/lib/hakuneko/engine/base/connectors/mangadex.html
+++ b/web/lib/hakuneko/engine/base/connectors/mangadex.html
@@ -26,9 +26,9 @@
                     label: 'Throttle Requests [ms]',
                     description: 'Enter the timespan in [ms] to delay consecuitive HTTP requests.\nThe website may ban your IP for to many consecuitive requests.',
                     input: Input.numeric,
-                    min: 0,
+                    min: 1000,
                     max: 5000,
-                    value: 500
+                    value: 3000
                 }
             };
         }


### PR DESCRIPTION
the limit for mangadex is too short, which gets people regularly banned. Increase the limit to avoid this.