### PR TITLE
GitHub pages deployment

### DIFF
--- a/build-web.config
+++ b/build-web.config
@@ -1,6 +1,6 @@
 module.exports = {
     source: 'src/web',
-    target: 'build/latest',
+    target: 'build/web',
     version: 'lib/hakuneko/version.html',
     polymer: {
         entrypoint: 'index.html',

--- a/deploy-web.config
+++ b/deploy-web.config
@@ -1,5 +1,5 @@
 module.exports = {
     key: 'hakuneko.key',
-    source: 'build/latest',
-    target: './master'
+    build: 'build/web',
+    deploy: './master'
 }

--- a/deploy-web.config
+++ b/deploy-web.config
@@ -1,5 +1,5 @@
 module.exports = {
     key: 'hakuneko.key',
     source: 'build/latest',
-    target: '../releases/6.0'
+    target: './master'
 }

--- a/deploy-web.config
+++ b/deploy-web.config
@@ -3,5 +3,5 @@ module.exports = {
     build: './build/web',
     // The deployment directory must match the `applicationStartupURL` configuration in the desktop 
     // e.g. 'https://manga-download.gihub.io/hakuneko/master/latest'
-    deploy: './master'
+    deploy: './6.0'
 }

--- a/deploy-web.config
+++ b/deploy-web.config
@@ -1,5 +1,5 @@
 module.exports = {
     key: 'hakuneko.key',
-    build: 'build/web',
+    build: './build/web',
     deploy: './master'
 }

--- a/deploy-web.config
+++ b/deploy-web.config
@@ -1,5 +1,7 @@
 module.exports = {
     key: 'hakuneko.key',
     build: './build/web',
+    // The deployment directory must match the `applicationStartupURL` configuration in the desktop 
+    // e.g. 'https://manga-download.gihub.io/hakuneko/master/latest'
     deploy: './master'
 }

--- a/deploy-web.js
+++ b/deploy-web.js
@@ -89,7 +89,7 @@ async function main() {
     let stashID = await gitStashPush(glob);
     await execute(`git checkout gh-pages`);
     await gitStashPop(stashID);
-    //await gitCommit(glob);
+    await gitCommit(glob);
 }
 
 // exit application as soon as any uncaught exception is thrown

--- a/deploy-web.js
+++ b/deploy-web.js
@@ -34,8 +34,8 @@ function execute(command, silent) {
 async function sslPack(archive, meta) {
     let key = path.resolve(config.key);
     let cwd = process.cwd();
-    if(config.source) {
-        process.chdir(config.source);
+    if(config.build) {
+        process.chdir(config.build);
     }
     await execute(`zip -r ${archive} .`);
     let signature = await execute(`openssl dgst -sha256 -hex -sign ${key} ${archive} | cut -d' ' -f2`);
@@ -48,8 +48,8 @@ async function sslPack(archive, meta) {
  */
 async function gitCommit() {
     let cwd = process.cwd();
-    if(config.source) {
-        process.chdir(config.target);
+    if(config.build) {
+        process.chdir(config.deploy);
     }
     await execute(`git add .`);
     await execute(`git commit -m 'updated releases'`);
@@ -64,11 +64,14 @@ async function main() {
     let meta = 'latest';
     let archive = Date.now().toString(36).toUpperCase() + '.zip';
     await sslPack(archive, meta);
-    await fs.remove(config.target);
-    await fs.mkdir(config.target);
-    await fs.move(path.resolve(config.source, meta), path.resolve(config.target, meta));
-    await fs.move(path.resolve(config.source, archive), path.resolve(config.target, archive));
-    await gitCommit();
+    await fs.remove(config.deploy);
+    await fs.mkdir(config.deploy);
+    await fs.move(path.resolve(config.source, meta), path.resolve(config.deploy, meta));
+    await fs.move(path.resolve(config.source, archive), path.resolve(config.deploy, archive));
+    // git stash directory `config.deploy`
+    // switch to gh-pages branch
+    // pop stash `config.deploy`
+    //await gitCommit();
 }
 
 // exit application as soon as any uncaught exception is thrown

--- a/deploy-web.js
+++ b/deploy-web.js
@@ -28,6 +28,27 @@ function execute(command, silent) {
 }
 
 /**
+ * NOTE: same function as in build-web => merge
+ * @param {string} identifier 
+ */
+async function gitStashPush(identifier) {
+    identifier = identifier || 'HTDOCS#' + Date.now().toString(16).toUpperCase();
+    await execute(`git stash push -u -m '${identifier}'`);
+    return identifier;
+}
+
+/**
+ * NOTE: same function as in build-web => merge
+ * @param {string} identifier 
+ */
+async function gitStashPop(identifier) {
+    let out = await execute(`git stash list`);
+    if(out.includes(identifier)) {
+        await execute(`git stash pop`);
+    }
+}
+
+/**
  * currently limited to unix systems only => TODO: use node modules instead of cmd tools
  * @param {string} archive 
  */
@@ -69,8 +90,11 @@ async function main() {
     await fs.move(path.resolve(config.source, meta), path.resolve(config.deploy, meta));
     await fs.move(path.resolve(config.source, archive), path.resolve(config.deploy, archive));
     // git stash directory `config.deploy`
+    //let stashID = await gitStashPush();
     // switch to gh-pages branch
+    //await ...
     // pop stash `config.deploy`
+    //await gitStashPop(stashID);
     //await gitCommit();
 }
 

--- a/deploy-web.js
+++ b/deploy-web.js
@@ -87,8 +87,8 @@ async function main() {
     await sslPack(archive, meta);
     await fs.remove(config.deploy);
     await fs.mkdir(config.deploy);
-    await fs.move(path.resolve(config.source, meta), path.resolve(config.deploy, meta));
-    await fs.move(path.resolve(config.source, archive), path.resolve(config.deploy, archive));
+    await fs.move(path.resolve(config.build, meta), path.resolve(config.deploy, meta));
+    await fs.move(path.resolve(config.build, archive), path.resolve(config.deploy, archive));
     // git stash directory `config.deploy`
     //let stashID = await gitStashPush();
     // switch to gh-pages branch

--- a/deploy-web.js
+++ b/deploy-web.js
@@ -68,14 +68,9 @@ async function sslPack(archive, meta) {
  * 
  */
 async function gitCommit() {
-    let cwd = process.cwd();
-    if(config.build) {
-        process.chdir(config.deploy);
-    }
     await execute(`git add .`);
     await execute(`git commit -m 'updated releases'`);
     await execute(`git push origin master`);
-    process.chdir(cwd);
 }
 
 /**
@@ -90,11 +85,11 @@ async function main() {
     await fs.move(path.resolve(config.build, meta), path.resolve(config.deploy, meta));
     await fs.move(path.resolve(config.build, archive), path.resolve(config.deploy, archive));
     // git stash directory `config.deploy`
-    //let stashID = await gitStashPush();
+    let stashID = await gitStashPush();
     // switch to gh-pages branch
     //await ...
     // pop stash `config.deploy`
-    //await gitStashPop(stashID);
+    await gitStashPop(stashID);
     //await gitCommit();
 }
 

--- a/deploy-web.js
+++ b/deploy-web.js
@@ -88,6 +88,7 @@ async function main() {
     await fs.move(path.resolve(config.build, archive), path.resolve(config.deploy, archive));
     let stashID = await gitStashPush(glob);
     await execute(`git checkout gh-pages`);
+    await fs.remove(config.deploy);
     await gitStashPop(stashID);
     await gitCommit(glob);
 }

--- a/deploy-web.js
+++ b/deploy-web.js
@@ -31,9 +31,9 @@ function execute(command, silent) {
  * NOTE: same function as in build-web => merge
  * @param {string} identifier 
  */
-async function gitStashPush(identifier) {
+async function gitStashPush(glob, identifier) {
     identifier = identifier || 'HTDOCS#' + Date.now().toString(16).toUpperCase();
-    await execute(`git stash push -u -m '${identifier}'`);
+    await execute(`git stash push -u -m '${identifier}' ${glob}`);
     return identifier;
 }
 
@@ -68,8 +68,9 @@ async function sslPack(archive, meta) {
  * 
  */
 async function gitCommit() {
+    // TODO: provide user credentials to push changes
     await execute(`git add .`);
-    await execute(`git commit -m 'updated releases'`);
+    await execute(`git commit -m 'deploy release: ${config.deploy}'`);
     await execute(`git push origin master`);
 }
 
@@ -84,11 +85,8 @@ async function main() {
     await fs.mkdir(config.deploy);
     await fs.move(path.resolve(config.build, meta), path.resolve(config.deploy, meta));
     await fs.move(path.resolve(config.build, archive), path.resolve(config.deploy, archive));
-    // git stash directory `config.deploy`
-    let stashID = await gitStashPush();
-    // switch to gh-pages branch
-    //await ...
-    // pop stash `config.deploy`
+    let stashID = await gitStashPush(path.join(config.deploy, '*'));
+    await execute(`git checkout gh-pages`);
     await gitStashPop(stashID);
     //await gitCommit();
 }

--- a/deploy-web.js
+++ b/deploy-web.js
@@ -67,9 +67,9 @@ async function sslPack(archive, meta) {
 /**
  * 
  */
-async function gitCommit() {
+async function gitCommit(glob) {
     // TODO: provide user credentials to push changes
-    await execute(`git add .`);
+    await execute(`git add ${glob}`);
     await execute(`git commit -m 'deploy release: ${config.deploy}'`);
     await execute(`git push origin master`);
 }
@@ -79,16 +79,17 @@ async function gitCommit() {
  */
 async function main() {
     let meta = 'latest';
+    let glob = path.join(config.deploy, '*');
     let archive = Date.now().toString(36).toUpperCase() + '.zip';
     await sslPack(archive, meta);
     await fs.remove(config.deploy);
     await fs.mkdir(config.deploy);
     await fs.move(path.resolve(config.build, meta), path.resolve(config.deploy, meta));
     await fs.move(path.resolve(config.build, archive), path.resolve(config.deploy, archive));
-    let stashID = await gitStashPush(path.join(config.deploy, '*'));
+    let stashID = await gitStashPush(glob);
     await execute(`git checkout gh-pages`);
     await gitStashPop(stashID);
-    //await gitCommit();
+    //await gitCommit(glob);
 }
 
 // exit application as soon as any uncaught exception is thrown

--- a/src/app/Configuration.js
+++ b/src/app/Configuration.js
@@ -23,7 +23,7 @@ module.exports = class Configuration {
     constructor(configuration) {
         let options = configuration || {};
         let applicationExecutableDirectory = path.dirname(electron.app.getPath('exe'));
-        this._applicationUpdateURL = options['applicationUpdateURL'] || 'https://manga-download.github.io/hakuneko/master/latest';
+        this._applicationUpdateURL = options['applicationUpdateURL'] || 'https://manga-download.github.io/hakuneko/6.0/latest';
         this._applicationStartupURL = options['applicationStartupURL'] || 'hakuneko://cache/index.html';
         this._applicationCacheDirectory = options['applicationCacheDirectory'] || path.join(applicationExecutableDirectory, 'cache');
         this._applicationUserDataDirectory = options['applicationUserDataDirectory'] || path.join(applicationExecutableDirectory, 'userdata');

--- a/src/app/Configuration.js
+++ b/src/app/Configuration.js
@@ -23,7 +23,7 @@ module.exports = class Configuration {
     constructor(configuration) {
         let options = configuration || {};
         let applicationExecutableDirectory = path.dirname(electron.app.getPath('exe'));
-        this._applicationUpdateURL = options['applicationUpdateURL'] || 'http://static.hakuneko.download/6.0/latest';
+        this._applicationUpdateURL = options['applicationUpdateURL'] || 'https://manga-download.gihub.io/hakuneko/master/latest';
         this._applicationStartupURL = options['applicationStartupURL'] || 'hakuneko://cache/index.html';
         this._applicationCacheDirectory = options['applicationCacheDirectory'] || path.join(applicationExecutableDirectory, 'cache');
         this._applicationUserDataDirectory = options['applicationUserDataDirectory'] || path.join(applicationExecutableDirectory, 'userdata');

--- a/src/app/Configuration.js
+++ b/src/app/Configuration.js
@@ -23,7 +23,7 @@ module.exports = class Configuration {
     constructor(configuration) {
         let options = configuration || {};
         let applicationExecutableDirectory = path.dirname(electron.app.getPath('exe'));
-        this._applicationUpdateURL = options['applicationUpdateURL'] || 'https://manga-download.gihub.io/hakuneko/master/latest';
+        this._applicationUpdateURL = options['applicationUpdateURL'] || 'https://manga-download.github.io/hakuneko/master/latest';
         this._applicationStartupURL = options['applicationStartupURL'] || 'hakuneko://cache/index.html';
         this._applicationCacheDirectory = options['applicationCacheDirectory'] || path.join(applicationExecutableDirectory, 'cache');
         this._applicationUserDataDirectory = options['applicationUserDataDirectory'] || path.join(applicationExecutableDirectory, 'userdata');

--- a/src/app/__tests__/Configuration.test.js
+++ b/src/app/__tests__/Configuration.test.js
@@ -85,7 +85,7 @@ describe('Configuration', function() {
     describe('applicationUpdateURL', function() {
         it('should have default after initialization', () => {
             let testee = new Configuration(undefined);
-            expect(testee.applicationUpdateURL).toEqual('http://static.hakuneko.download/6.0/latest');
+            expect(testee.applicationUpdateURL).toEqual('https://manga-download.github.io/hakuneko/6.0/latest');
         });
         it('should be overwritten by update URL from options', () => {
             let testee = new Configuration(expected);

--- a/src/app/__tests__/ConfigurationDarwin.test.js
+++ b/src/app/__tests__/ConfigurationDarwin.test.js
@@ -86,7 +86,7 @@ var suite = function() {
     describe('applicationUpdateURL', function() {
         it('should have default after initialization', () => {
             let testee = new Configuration(undefined);
-            expect(testee.applicationUpdateURL).toEqual('http://static.hakuneko.download/6.0/latest');
+            expect(testee.applicationUpdateURL).toEqual('https://manga-download.github.io/hakuneko/6.0/latest');
         });
         it('should be overwritten by update URL from options', () => {
             let testee = new Configuration(expected);

--- a/src/app/__tests__/ConfigurationLinux.test.js
+++ b/src/app/__tests__/ConfigurationLinux.test.js
@@ -86,7 +86,7 @@ var suite = function() {
     describe('applicationUpdateURL', function() {
         it('should have default after initialization', () => {
             let testee = new Configuration(undefined);
-            expect(testee.applicationUpdateURL).toEqual('http://static.hakuneko.download/6.0/latest');
+            expect(testee.applicationUpdateURL).toEqual('https://manga-download.github.io/hakuneko/6.0/latest');
         });
         it('should be overwritten by update URL from options', () => {
             let testee = new Configuration(expected);

--- a/src/app/__tests__/ConfigurationWindows.tests.js
+++ b/src/app/__tests__/ConfigurationWindows.tests.js
@@ -87,7 +87,7 @@ var suite = function() {
     describe('applicationUpdateURL', function() {
         it('should have default after initialization', () => {
             let testee = new Configuration(undefined);
-            expect(testee.applicationUpdateURL).toEqual('http://static.hakuneko.download/6.0/latest');
+            expect(testee.applicationUpdateURL).toEqual('https://manga-download.github.io/hakuneko/6.0/latest');
         });
         it('should be overwritten by update URL from options', () => {
             let testee = new Configuration(expected);


### PR DESCRIPTION
Changed deployment script to publish new releases to the [manga-download/hakuneko/gh-pages](https://github.com/manga-download/hakuneko/tree/gh-pages) branch of this repository instead of the separate [manga-download/releases](https://github.com/manga-download/releases) repository.