### PR TITLE
[manganel] fixed redirection issue for affiliates

### DIFF
--- a/src/web/mjs/connectors/MangaNel.mjs
+++ b/src/web/mjs/connectors/MangaNel.mjs
@@ -79,7 +79,7 @@ export default class MangaNel extends Connector {
                 return response.text();
             } )
             .then( data => {
-                let redirect = data.match( /window.location.assign\(\s*"([^"]+)"\s*\)/ );
+                let redirect = data.match( /window.location.assign\(\s*['"]([^'"]+)['"]\s*\)/ );
                 return this.fetchDOM( redirect && !redirect[1].includes('manganel') ? redirect[1] : uri, this.queryChapters );
             } )
             .then( data => {

--- a/src/web/mjs/connectors/MangaNel.mjs
+++ b/src/web/mjs/connectors/MangaNel.mjs
@@ -80,7 +80,7 @@ export default class MangaNel extends Connector {
             } )
             .then( data => {
                 let redirect = data.match( /window.location.assign\(\s*['"]([^'"]+)['"]\s*\)/ );
-                return this.fetchDOM( redirect && !this.id === 'manganel' ? redirect[1] : uri, this.queryChapters );
+                return this.fetchDOM( this.id !== 'manganel' && redirect ? redirect[1] : uri, this.queryChapters );
             } )
             .then( data => {
                 let chapterList = data.map( element => {

--- a/src/web/mjs/connectors/MangaNel.mjs
+++ b/src/web/mjs/connectors/MangaNel.mjs
@@ -80,7 +80,7 @@ export default class MangaNel extends Connector {
             } )
             .then( data => {
                 let redirect = data.match( /window.location.assign\(\s*['"]([^'"]+)['"]\s*\)/ );
-                return this.fetchDOM( redirect && !redirect[1].includes('manganel') ? redirect[1] : uri, this.queryChapters );
+                return this.fetchDOM( redirect && !this.id === 'manganel' ? redirect[1] : uri, this.queryChapters );
             } )
             .then( data => {
                 let chapterList = data.map( element => {

--- a/src/web/mjs/connectors/MangaNel.mjs
+++ b/src/web/mjs/connectors/MangaNel.mjs
@@ -79,8 +79,8 @@ export default class MangaNel extends Connector {
                 return response.text();
             } )
             .then( data => {
-                let redirect = data.match( /window\.location\s*=\s*['"](http[s]:\/\/[^'"]+)['"]\s*[;\r\n]/ );
-                return this.fetchDOM( redirect ? redirect[1] : uri, this.queryChapters );
+                let redirect = data.match( /window.location.assign\(\s*"([^"]+)"\s*\)/ );
+                return this.fetchDOM( redirect && !redirect[1].includes('manganel') ? redirect[1] : uri, this.queryChapters );
             } )
             .then( data => {
                 let chapterList = data.map( element => {


### PR DESCRIPTION
MangaNel introduced a new redirection trap to bypass the usage of `manganel.unblocker.cc` and HakuNeko also fell into this trap, because it was thinking of following a redirect of an affiliate (e.g. MangaKakalot) website
Resolves #547 
Resolves #548 