### PR TITLE
Main Window Frameless

### DIFF
--- a/src/app/ElectronBootstrap.js
+++ b/src/app/ElectronBootstrap.js
@@ -258,7 +258,8 @@ module.exports = class ElectronBootstrap {
                 experimentalFeatures: true,
                 nodeIntegration: true,
                 webSecurity: false // required to open local images in browser
-            }
+            },
+            frame: false
         });
 
         this._setupBeforeSendHeaders();

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+<head> 
     <meta charset="utf-8">
     <title>HakuNeko</title>
     <link rel="icon" href="./img/logo.png">
@@ -89,6 +89,25 @@
 
         main();
     </script>
+    <script>
+        this.win=require('electron').remote.getCurrentWindow();
+
+        function minimizeWindow(){
+            this.win.minimize();
+        }
+
+        function maximizeWindow(){
+            if (! this.win.isMaximized()) {
+                this.win.maximize();
+            } else {
+                this.win.unmaximize();
+            }
+        }
+
+        function closeWindow(){
+            this.win.close();
+        }
+    </script>
     <style>
         html, body {
             margin: 0;
@@ -126,9 +145,24 @@
             right: 1em;
             cursor: pointer;
         }
+
+        #default_menubar {
+            text-align : right;
+            -webkit-app-region: drag;
+        }
+
+        #default_menubar > span {
+            -webkit-app-region: no-drag;
+            cursor: pointer;
+        }
     </style>
 </head>
 <body>
+    <div id="default_menubar">
+        <span id="win_minimize" onclick="minimizeWindow()" title="Minimize Window">🗕</span>
+        <span id="win_maximize" onclick="maximizeWindow()" title="Maximize Window">🗖</span>
+        <span id="win_close" onclick="closeWindow()" title="Close Window">🗙</span>
+    </div>
     <div id="notification">
         A new <strong>HakuNeko Desktop Client</strong> is available for download on
         <a href="https://github.com/manga-download/hakuneko/releases" target="_blank">GitHub</a>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -159,9 +159,10 @@
 </head>
 <body>
     <div id="default_menubar">
-        <span id="win_minimize" onclick="minimizeWindow()" title="Minimize Window">🗕</span>
-        <span id="win_maximize" onclick="maximizeWindow()" title="Maximize Window">🗖</span>
-        <span id="win_close" onclick="closeWindow()" title="Close Window">🗙</span>
+        <!-- Using UTF8 as base64 PNG 🗕🗖🗙 because of MacOS -->
+        <span id="win_minimize" onclick="minimizeWindow()" title="Minimize Window"><img alt="minimize" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABcSURBVEhLYxgFo2AUjIJRMApGATGAEUpjgKioqP+vXr2C8vADMTExhmXLluE0CytQUVH5D6SIwlC1WAETlKYZwOmtCRMmNPz48QPKww84ODgYCgoKGqBcegIGBgA9XBrRMdUaKQAAAABJRU5ErkJggg==" /></span>
+        <span id="win_maximize" onclick="maximizeWindow()" title="Maximize Window"><img alt="maximize" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACESURBVEhL7ZZRCsAgCIZtDx2i57p0V4teO0QvLsGxxgYSw8HADyQR9McwySEiaLLxqYYJiKgLAE3RYTFGGqlXRjXmmuodXN5BSgm99xBC4MgarTXovUMpxXFo9DS1Q+3lnId7xlaMcj+/IhMQMQERExC5CdRa2VvnMXfeGxrr+u+/CoAdAOyl6foWTQEAAAAASUVORK5CYII=" /></span>
+        <span id="win_close" onclick="closeWindow()" title="Close Window"><img alt="close" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFLSURBVEhL7ZUxqoQwEIazDxa8g6CFlZ2ghSAiHsA9guWWHkC8hY0LImLjBTyB3kO8SdZZNC+J0aTZbgc+zPwZ5wd14g1jjL4Zf9v1a/EzkMbhJb9eLzzPM7IsCz2fz9smX8YwDHiaJqTrOsqyjL0HDGjiOAbHD3merxK7z9N1HdY07VPved4qsftMAjweD2IgM2nbljQHgiBYZbaGSXYcxyE3nZk0TcM0N03zUAMchJ0rk6qq8P1+J3tnzQGhuCMyKctSuTkgFGl4ExpZc0Ao8ohMVJoDSoOWpum2+o8kSbaVJESuNPwLpVGZE6G4U9c109wwDGzbNslVTIQiwA8R/cxd1yW6zEQo0uPPN9/xfZ/sX5kchL7vlSYUgKOBNimKYpXZGiYB6MNO5VMMw5DUiw670890bY6WZZEe1+M43qIo2rJj/H76kkDoDZkbCAEJwDteAAAAAElFTkSuQmCC" /></span>
     </div>
     <div id="notification">
         A new <strong>HakuNeko Desktop Client</strong> is available for download on

--- a/src/web/lib/hakuneko/frontend@classic-dark/app.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/app.html
@@ -47,6 +47,7 @@
             }
             hakuneko-menu {
                 flex: 0;
+                -webkit-app-region: drag;
             }
             hakuneko-jobs {
                 flex: 0;

--- a/src/web/lib/hakuneko/frontend@classic-dark/connectors.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/connectors.html
@@ -309,7 +309,7 @@
              */
             _openLink(evt, link) {
                 if(link) {
-                    let popup = window.open(link, evt.model.label, 'nodeIntegration=no');
+                    let popup = window.open(link, evt.model.label, 'frame=true,nodeIntegration=no');
                     // disable onbeforeunload periodically (in case of navigation) to prevent blocking window close
                     let watchdog = setInterval(() => {
                         if(popup.closed) {

--- a/src/web/lib/hakuneko/frontend@classic-dark/menu.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/menu.html
@@ -130,9 +130,9 @@
         <i class="fas fa-fw fa-bars fa-2x item button" title="Toggle menu" on-click="togglePopup"></i>
         <span class="title">HakuNeko</span>
         <span class="right">
-        <i class="far fa-fw fa-window-minimize item button" title="Minize HakuNeko" on-click="minimizeWindow"></i>
-        <i class="far fa-fw fa-window-maximize item button" title="Maximize HakuNeko" on-click="maximizeWindow"></i>
-        <i class="far fa-fw fa-2x fa-window-close item button" title="Close HakuNeko" on-click="closeWindow"></i>
+        <i class="far fa-fw fa-window-minimize item button" title="Minize HakuNeko" onclick="minimizeWindow()"></i>
+        <i class="far fa-fw fa-window-maximize item button" title="Maximize HakuNeko" onclick="maximizeWindow()"></i>
+        <i class="far fa-fw fa-2x fa-window-close item button" title="Close HakuNeko" onclick="closeWindow()"></i>
         </span>
         <div class$="popup [[ getPopupClass(popupVisibility) ]]">
             <div class="separator">
@@ -237,7 +237,6 @@
                 this.version = Engine.Version;
                 this.popupVisibility = false;
                 this.settingCategories = Engine.Settings.getCategorizedSettings();
-                this.win=require('electron').remote.getCurrentWindow();
             }
 
             getPopupClass(visibility) {
@@ -311,21 +310,6 @@
                 }
             }
 
-            minimizeWindow(event){
-                this.win.minimize();
-            }
-
-            maximizeWindow(event){
-                if (!this.win.isMaximized()) {
-                    this.win.maximize();
-                } else {
-                    this.win.unmaximize();
-                }
-            }
-
-            closeWindow (event){
-                this.win.close();
-            }
         }
         window.customElements.define(HakunekoMenu.is, HakunekoMenu);
     </script>

--- a/src/web/lib/hakuneko/frontend@classic-dark/menu.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/menu.html
@@ -106,6 +106,10 @@
             }
             .button {
                 cursor: pointer;
+                -webkit-app-region: no-drag;
+            }
+            .right {
+                float: right;
             }
             .buttons {
                 display: flex;
@@ -125,6 +129,11 @@
         </style>
         <i class="fas fa-fw fa-bars fa-2x item button" title="Toggle menu" on-click="togglePopup"></i>
         <span class="title">HakuNeko</span>
+        <span class="right">
+        <i class="far fa-fw fa-window-minimize item button" title="Minize HakuNeko" on-click="minimizeWindow"></i>
+        <i class="far fa-fw fa-window-maximize item button" title="Maximize HakuNeko" on-click="maximizeWindow"></i>
+        <i class="far fa-fw fa-2x fa-window-close item button" title="Close HakuNeko" on-click="closeWindow"></i>
+        </span>
         <div class$="popup [[ getPopupClass(popupVisibility) ]]">
             <div class="separator">
                 <label>About</label>
@@ -228,6 +237,7 @@
                 this.version = Engine.Version;
                 this.popupVisibility = false;
                 this.settingCategories = Engine.Settings.getCategorizedSettings();
+                this.win=require('electron').remote.getCurrentWindow();
             }
 
             getPopupClass(visibility) {
@@ -299,6 +309,22 @@
                     // reset input file field or it cannot be used again
                     this.$.importFile.value = null;
                 }
+            }
+
+            minimizeWindow(event){
+                this.win.minimize();
+            }
+
+            maximizeWindow(event){
+                if (!this.win.isMaximized()) {
+                    this.win.maximize();
+                } else {
+                    this.win.unmaximize();
+                }
+            }
+
+            closeWindow (event){
+                this.win.close();
             }
         }
         window.customElements.define(HakunekoMenu.is, HakunekoMenu);

--- a/src/web/lib/hakuneko/frontend@classic-dark/theme.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/theme.html
@@ -1,4 +1,7 @@
 <style>
+    #default_menubar {
+        display:none;
+    }
     /* Font faces needs to be imported on the root level (does not work within shadow DOM scope) */
     @font-face {
         font-family: "Font Awesome 5 Brands";

--- a/src/web/lib/hakuneko/frontend@classic-light/app.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/app.html
@@ -47,6 +47,7 @@
             }
             hakuneko-menu {
                 flex: 0;
+                -webkit-app-region: drag;
             }
             hakuneko-jobs {
                 flex: 0;

--- a/src/web/lib/hakuneko/frontend@classic-light/connectors.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/connectors.html
@@ -309,7 +309,7 @@
              */
             _openLink(evt, link) {
                 if(link) {
-                    let popup = window.open(link, evt.model.label, 'nodeIntegration=no');
+                    let popup = window.open(link, evt.model.label, 'frame=true,nodeIntegration=no');
                     // disable onbeforeunload periodically (in case of navigation) to prevent blocking window close
                     let watchdog = setInterval(() => {
                         if(popup.closed) {

--- a/src/web/lib/hakuneko/frontend@classic-light/menu.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/menu.html
@@ -106,6 +106,10 @@
             }
             .button {
                 cursor: pointer;
+                -webkit-app-region: no-drag;
+            }
+            .right {
+                float: right;
             }
             .buttons {
                 display: flex;
@@ -125,6 +129,11 @@
         </style>
         <i class="fas fa-fw fa-bars fa-2x item button" title="Toggle menu" on-click="togglePopup"></i>
         <span class="title">HakuNeko</span>
+        <span class="right">
+            <i class="far fa-fw fa-window-minimize item button" title="Minize HakuNeko" on-click="minimizeWindow"></i>
+            <i class="far fa-fw fa-window-maximize item button" title="Maximize HakuNeko" on-click="maximizeWindow"></i>
+            <i class="far fa-fw fa-2x fa-window-close item button" title="Close HakuNeko" on-click="closeWindow"></i>
+        </span>
         <div class$="popup [[ getPopupClass(popupVisibility) ]]">
             <div class="separator">
                 <label>About</label>
@@ -228,6 +237,7 @@
                 this.version = Engine.Version;
                 this.popupVisibility = false;
                 this.settingCategories = Engine.Settings.getCategorizedSettings();
+                this.win=require('electron').remote.getCurrentWindow();
             }
 
             getPopupClass(visibility) {
@@ -299,6 +309,22 @@
                     // reset input file field or it cannot be used again
                     this.$.importFile.value = null;
                 }
+            }
+
+            minimizeWindow(event){
+                this.win.minimize();
+            }
+
+            maximizeWindow(event){
+                if (!this.win.isMaximized()) {
+                    this.win.maximize();
+                } else {
+                    this.win.unmaximize();
+                }
+            }
+
+            closeWindow (event){
+                this.win.close();
             }
         }
         window.customElements.define(HakunekoMenu.is, HakunekoMenu);

--- a/src/web/lib/hakuneko/frontend@classic-light/menu.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/menu.html
@@ -130,9 +130,9 @@
         <i class="fas fa-fw fa-bars fa-2x item button" title="Toggle menu" on-click="togglePopup"></i>
         <span class="title">HakuNeko</span>
         <span class="right">
-            <i class="far fa-fw fa-window-minimize item button" title="Minize HakuNeko" on-click="minimizeWindow"></i>
-            <i class="far fa-fw fa-window-maximize item button" title="Maximize HakuNeko" on-click="maximizeWindow"></i>
-            <i class="far fa-fw fa-2x fa-window-close item button" title="Close HakuNeko" on-click="closeWindow"></i>
+            <i class="far fa-fw fa-window-minimize item button" title="Minize HakuNeko" onclick="minimizeWindow()"></i>
+            <i class="far fa-fw fa-window-maximize item button" title="Maximize HakuNeko" onclick="maximizeWindow()"></i>
+            <i class="far fa-fw fa-2x fa-window-close item button" title="Close HakuNeko" onclick="closeWindow()"></i>
         </span>
         <div class$="popup [[ getPopupClass(popupVisibility) ]]">
             <div class="separator">
@@ -237,7 +237,6 @@
                 this.version = Engine.Version;
                 this.popupVisibility = false;
                 this.settingCategories = Engine.Settings.getCategorizedSettings();
-                this.win=require('electron').remote.getCurrentWindow();
             }
 
             getPopupClass(visibility) {
@@ -309,22 +308,6 @@
                     // reset input file field or it cannot be used again
                     this.$.importFile.value = null;
                 }
-            }
-
-            minimizeWindow(event){
-                this.win.minimize();
-            }
-
-            maximizeWindow(event){
-                if (!this.win.isMaximized()) {
-                    this.win.maximize();
-                } else {
-                    this.win.unmaximize();
-                }
-            }
-
-            closeWindow (event){
-                this.win.close();
             }
         }
         window.customElements.define(HakunekoMenu.is, HakunekoMenu);

--- a/src/web/lib/hakuneko/frontend@classic-light/theme.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/theme.html
@@ -1,4 +1,7 @@
 <style>
+     #default_menubar {
+        display:none;
+    }
     /* Font faces needs to be imported on the root level (does not work within shadow DOM scope) */
     @font-face {
         font-family: "Font Awesome 5 Brands";


### PR DESCRIPTION
Changes the main window to frameless.
Top left menu is now draggable and includes minimize,maximize and close buttons.
Connectors's browser window is still with frame enabled.

Todo :
- [X] Check pre-flight-check steps that can be related to this change and detail the following tests
- [x] Test on Windows
- - [X] The default menubar should appear during loading then disapears after theme load
- - [X] Button Minimize sends hakunko to the minimized state
- - [X] Button Maximize sends hakunko to the full size of the screen (but not in "full screen" mode)
- - [X] Clicking on Maximize again restores the window to it's original size
- - [X] The windows is only draggable on the top left part (#Menu), move it around while in non maximized state.
- - [X] Double clicking on the draggable part is triggering the Maximize function (do the same tests as before)
- - [X] The configuration menu (on top left) is still clickable.
- - [X] The unmaximized window can be resized in 3 corners (top right, bottom right, bottom left). The resize icon appears when on the 4 edge (top bottom, left, right)
- - [X] Open a connector's website from the connector pannel and asses that the window topbar is here as well as system controls (min, max, close buttons)
- - [X] Button Close closes hakunko (and no electron process is still runing afterwards)
- - [X] Run pre-flight steps 40 & 41
- [x] Test on Linux
- - [x] The default menubar should appear during loading then disapears after theme load
- - [x] Button Minimize sends hakunko to the minimized state
- - [x] Button Maximize sends hakunko to the full size of the screen (but not in "full screen" mode)
- - [x] Clicking on Maximize again restores the window to it's original size
- - [x] The windows is only draggable on the top left part (#Menu), move it around while in non maximized state.
- - [x] Double clicking on the draggable part is triggering the Maximize function (do the same tests as before)
- - [x] The configuration menu (on top left) is still clickable.
- - [x] The unmaximized window can be resized in 3 corners (top right, bottom right, bottom left). The resize icon appears when on the 4 edge (top bottom, left, right)
- - [x] Open a connector's website from the connector pannel and asses that the window topbar is here as well as system controls (min, max, close buttons)
- - [x] Button Close closes hakunko (and no electron process is still runing afterwards)
- - [x] Run pre-flight steps 40 & 41
- [x] Test on MacOS
- ⚠️ The default menubar should appear during loading then disapears after theme load
Menu bar appears, but there are 3 squares instead of min/max/close symbols
- - [x] Button Minimize sends hakunko to the minimized state
- - [x] Button Maximize sends hakunko to the full size of the screen (but not in "full screen" mode)
- - [x] Clicking on Maximize again restores the window to it's original size
- - [x] The windows is only draggable on the top left part (#Menu), move it around while in non maximized state.
- ❌ Double clicking on the draggable part is triggering the Maximize function (do the same tests as before)
- - [x] The configuration menu (on top left) is still clickable.
- - [x] The unmaximized window can be resized in 3 corners (top right, bottom right, bottom left). The resize icon appears when on the 4 edge (top bottom, left, right)
- - [x] Open a connector's website from the connector pannel and asses that the window topbar is here as well as system controls (min, max, close buttons)
- - [x] Button Close closes hakunko (and no electron process is still runing afterwards)
- - [x] Run pre-flight steps 40 & 41