### PR TITLE
Fixes #1517 MangaHub MangaHere API url

### DIFF
--- a/src/web/mjs/connectors/MangaHub.mjs
+++ b/src/web/mjs/connectors/MangaHub.mjs
@@ -9,7 +9,7 @@ export default class MangaHub extends Connector {
         super.label = 'MangaHub';
         this.tags = [ 'manga', 'english' ];
         this.url = 'https://mangahub.io';
-        this.apiURL = 'https://api2.mangahub.io/graphql';
+        this.apiURL = 'https://api.mghubcdn.com/graphql';
         this.cdnURL = 'https://img.mghubcdn.com/file/imghub/';
 
         this.path = 'm01';


### PR DESCRIPTION
Mangahub changed API to https://api.mghubcdn.com/graphql
Fixes #1517