### PR TITLE
[ReadMangaToday] Remove Ads images - Fixes #1541

### DIFF
--- a/src/web/mjs/connectors/ReadMNG.mjs
+++ b/src/web/mjs/connectors/ReadMNG.mjs
@@ -71,21 +71,13 @@ export default class ReadMNG extends Connector {
             } );
     }
 
-    /*
-    * Used to check if the img is not an ad
-    */
-    checkMangaImage(img) {
-        return img.classList.contains('img-responsive');
-    }
-
     /**
      *
      */
     _getPageList( manga, chapter, callback ) {
         let request = new Request( this.url + chapter.id + '/all-pages', this.requestOptions );
-        this.fetchDOM( request, 'div.page_chapter source' )
+        this.fetchDOM( request, 'div.page_chapter source[class*="img-responsive"]' )
             .then( data => {
-                data = data.filter(this.checkMangaImage);
                 let pageLinks = data.map( element => this.createConnectorURI( this.getAbsolutePath( element, request.url ) ) );
                 callback( null, pageLinks );
             } )

--- a/src/web/mjs/connectors/ReadMNG.mjs
+++ b/src/web/mjs/connectors/ReadMNG.mjs
@@ -71,6 +71,13 @@ export default class ReadMNG extends Connector {
             } );
     }
 
+    /*
+    * Used to check if the img is not an ad
+    */
+    checkMangaImage(img) {
+        return img.classList.contains('img-responsive');
+    }
+
     /**
      *
      */
@@ -78,6 +85,7 @@ export default class ReadMNG extends Connector {
         let request = new Request( this.url + chapter.id + '/all-pages', this.requestOptions );
         this.fetchDOM( request, 'div.page_chapter source' )
             .then( data => {
+                data = data.filter(this.checkMangaImage);
                 let pageLinks = data.map( element => this.createConnectorURI( this.getAbsolutePath( element, request.url ) ) );
                 callback( null, pageLinks );
             } )


### PR DESCRIPTION
Fixes #1541 by filtering images that have the class "img-responsive" (ads don't)

Checked a few random mangas and the images have the same count as on the site and display correctly.

Checked chapter download, works fine.