### PR TITLE
[MangaHere][MangaFox] Fix download and issue in viewer

### DIFF
--- a/src/web/mjs/connectors/MangaFox.mjs
+++ b/src/web/mjs/connectors/MangaFox.mjs
@@ -138,6 +138,7 @@ export default class MangaFox extends Connector {
         let request = new Request( this.url + chapter.id, this.requestOptions );
         Engine.Request.fetchUI( request, this.script )
             .then( pageList => {
+                pageList.pop();
                 callback( null, pageList );
             } )
             .catch( error => {


### PR DESCRIPTION
Last image on every chapter was randomly failing (http 404). In such case download is not working.
When not failing it's in fact an inserted ad not related to the scanlation source.

Done in this PR : Always remove last image in chapter.

Possible alternative: you can see that the difference between the last 2 images is the j2 becoming jz (all previous images in the chapter were with j2). This "offset" changed for every chapter
273.0/compressed/j20200403_162151_046.jpg
273.0/compressed/jz0200403_162151_046.jpg
However it doesn't seem reliable as some manga have this offset on the 4th char.

The only regular way to solve this was by simply removing the last image.