### PR TITLE
[DoujinDesu] Website domain change

### DIFF
--- a/src/web/mjs/connectors/DoujinDesu.mjs
+++ b/src/web/mjs/connectors/DoujinDesu.mjs
@@ -7,7 +7,7 @@ export default class DoujinDesu extends BloggerManga {
         super.id = 'doujindesu';
         super.label = 'DoujinDesu';
         this.tags = ['hentai', 'indonesian'];
-        this.url = 'https://www.doujindesu.cc';
+        this.url = 'https://www.doujindesu.site';
         this.urlBlog = 'https://doujindesu.blogspot.com';
 
         this.path = '';


### PR DESCRIPTION
DoujinDesu Hentai domain changed to .site (discovered by luck while checking the main source of hakuneko traffic on github. Yeah i felt like justifying the context of this PR 🐑  ).

Support for indonesians fap time during containment  😄 