### PR TITLE
FIX- Frameless issue with menu buttons

### DIFF
--- a/src/web/lib/hakuneko/frontend@classic-dark/menu.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/menu.html
@@ -270,7 +270,7 @@
              * otherwise the window cannot be closed anymore (electron does not show the confirmation).
              */
             openWindow(event) {
-                let popup = window.open(event.target.dataset.href, '', 'nodeIntegration=no');
+                let popup = window.open(event.target.dataset.href, '', 'frame=true,nodeIntegration=no');
                 // disable onbeforeunload periodically (in case of navigation) to prevent blocking window close
                 let watchdog = setInterval(() => {
                     if(popup.closed) {

--- a/src/web/lib/hakuneko/frontend@classic-light/menu.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/menu.html
@@ -270,7 +270,7 @@
              * otherwise the window cannot be closed anymore (electron does not show the confirmation).
              */
             openWindow(event) {
-                let popup = window.open(event.target.dataset.href, '', 'nodeIntegration=no');
+                let popup = window.open(event.target.dataset.href, '', 'frame=true,nodeIntegration=no');
                 // disable onbeforeunload periodically (in case of navigation) to prevent blocking window close
                 let watchdog = setInterval(() => {
                     if(popup.closed) {


### PR DESCRIPTION
The buttons (github doc, issues etc...)in the menu opens a browser page with an url, but then the close buttons aren't there because of the frameless mode.
Adding back the default frame menu in such cases.