### PR TITLE
FEAT-MagicScrollv2 improvement and auto next chapter

### DIFF
--- a/src/web/lib/hakuneko/frontend@classic-dark/pages.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/pages.html
@@ -538,11 +538,11 @@
                 if(images[images.length-1].getBoundingClientRect().bottom-window.innerHeight < 0)
                 {
                     // Should we go to next chapter because we previouysly reached the end of page ?
-                    if (this.autoNextChapter) { this.requestChapterUp(); return; };
+                    if (this.autoNextChapter) { return this.requestChapterUp(); };
                     // Prepare for next chapter
                     this.autoNextChapter = true;
                     // Todo: Find a way to popup that you have to press spacebar again within 4s
-                    setInterval(function(){ this.autoNextChapter=false; }, 4000);
+                    setTimeout(function(){ this.autoNextChapter=false; }, 4000);
                     return;
                 }
                 // Lets stay on current page

--- a/src/web/lib/hakuneko/frontend@classic-dark/pages.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/pages.html
@@ -194,6 +194,7 @@
                 this.hls = undefined;
                 this.ass = undefined;
                 this.videoResizeObserver = new ResizeObserver( this.onVideoResized.bind( this ) );
+                this.autoNextChapter = false;
             }
 
             /**
@@ -455,6 +456,7 @@
              * fire event to request the next chapter
              */
             requestChapterUp( event ) {
+                this.autoNextChapter=false;
                 window.dispatchEvent( new CustomEvent( 'chapterUp', { detail: this.selectedChapter } ) );
             }
 
@@ -532,35 +534,55 @@
              */
             scrollMagic(defaultDistance) {
                 let images = this.$.container.querySelectorAll('.image');
+                // Are we at the end of the page
+                if(images[images.length-1].getBoundingClientRect().bottom-window.innerHeight < 0)
+                {
+                    // Should we go to next chapter because we previouysly reached the end of page ?
+                    if (this.autoNextChapter) { this.requestChapterUp(); return; };
+                    // Prepare for next chapter
+                    this.autoNextChapter = true;
+                    // Todo: Find a way to popup that you have to press spacebar again within 4s
+                    setInterval(function(){ this.autoNextChapter=false; }, 4000);
+                    return;
+                }
+                // Lets stay on current page
                 // Find current image within view
-                let currentScrollImages = [...images].filter(image => {
+                let targetScrollImages = [...images].filter(image => {
                     let rect = image.getBoundingClientRect();
                     return (rect.top <= window.innerHeight && rect.bottom >1);
                 });
 
-                // If multiple images filtered, get the first one. If none scroll to the top image
-                let currentScrollImage = currentScrollImages[0] || images[0];
+                // If multiple images filtered, get the last one. If none scroll use the top image
+                let targetScrollImage = targetScrollImages[targetScrollImages.length-1] || images[0];
 
-                // Do we stay on current image ?
-                if (window.innerHeight +1 < currentScrollImage.getBoundingClientRect().bottom ) {
-                    // Scroll default or scroll to bottom of current image
+                // Is the target image top within view ? then scroll to the top of it
+                if (targetScrollImage.getBoundingClientRect().top > 1 ) {
+                    // Scroll to it
+                    targetScrollImage.scrollIntoView({ 
+                        behavior: 'smooth' 
+                    });
+                }
+                // Do we stay within target ? (bottom is further than current view)
+                else if (window.innerHeight +1 < targetScrollImage.getBoundingClientRect().bottom ){
                     this.$.container.scrollBy({ 
-                        top: Math.min(defaultDistance,currentScrollImage.getBoundingClientRect().bottom-window.innerHeight),
+                        top: Math.min(defaultDistance,targetScrollImage.getBoundingClientRect().bottom-window.innerHeight),
                         left: 0, 
                         behavior: 'smooth' 
                     });
-                } else {
+                }
+                // We have to try to get to next image
+                else {
                     // Find next image
-                    let nextScrollImage = currentScrollImage.nextElementSibling;
-                    if (nextScrollImage) {
-                        // Scroll to it
-                        nextScrollImage.scrollIntoView({ 
-                            behavior: 'smooth' 
-                        });
-                    }
+                    let nextScrollImage = targetScrollImage.nextElementSibling;
+                    // Scroll to it
+                    nextScrollImage.scrollIntoView({ 
+                        behavior: 'smooth' 
+                    });
                 }
             }
+
         }
+
         window.customElements.define( HakunekoPages.is, HakunekoPages );
         
         function scrollSmoothly(element, distance) {

--- a/src/web/lib/hakuneko/frontend@classic-light/pages.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/pages.html
@@ -538,11 +538,11 @@
                 if(images[images.length-1].getBoundingClientRect().bottom-window.innerHeight < 0)
                 {
                     // Should we go to next chapter because we previouysly reached the end of page ?
-                    if (this.autoNextChapter) { this.requestChapterUp(); return; };
+                    if (this.autoNextChapter) { return this.requestChapterUp(); };
                     // Prepare for next chapter
                     this.autoNextChapter = true;
                     // Todo: Find a way to popup that you have to press spacebar again within 4s
-                    setInterval(function(){ this.autoNextChapter=false; }, 4000);
+                    setTimeout(function(){ this.autoNextChapter=false; }, 4000);
                     return;
                 }
                 // Lets stay on current page

--- a/src/web/lib/hakuneko/frontend@classic-light/pages.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/pages.html
@@ -194,6 +194,7 @@
                 this.hls = undefined;
                 this.ass = undefined;
                 this.videoResizeObserver = new ResizeObserver( this.onVideoResized.bind( this ) );
+                this.autoNextChapter = false;
             }
 
             /**
@@ -455,6 +456,7 @@
              * fire event to request the next chapter
              */
             requestChapterUp( event ) {
+                this.autoNextChapter=false;
                 window.dispatchEvent( new CustomEvent( 'chapterUp', { detail: this.selectedChapter } ) );
             }
 
@@ -532,35 +534,55 @@
              */
              scrollMagic(defaultDistance) {
                 let images = this.$.container.querySelectorAll('.image');
+                // Are we at the end of the page
+                if(images[images.length-1].getBoundingClientRect().bottom-window.innerHeight < 0)
+                {
+                    // Should we go to next chapter because we previouysly reached the end of page ?
+                    if (this.autoNextChapter) { this.requestChapterUp(); return; };
+                    // Prepare for next chapter
+                    this.autoNextChapter = true;
+                    // Todo: Find a way to popup that you have to press spacebar again within 4s
+                    setInterval(function(){ this.autoNextChapter=false; }, 4000);
+                    return;
+                }
+                // Lets stay on current page
                 // Find current image within view
-                let currentScrollImages = [...images].filter(image => {
+                let targetScrollImages = [...images].filter(image => {
                     let rect = image.getBoundingClientRect();
                     return (rect.top <= window.innerHeight && rect.bottom >1);
                 });
 
-                // If multiple images filtered, get the first one. If none scroll to the top image
-                let currentScrollImage = currentScrollImages[0] || images[0];
+                // If multiple images filtered, get the last one. If none scroll use the top image
+                let targetScrollImage = targetScrollImages[targetScrollImages.length-1] || images[0];
 
-                // Do we stay on current image ?
-                if (window.innerHeight +1 < currentScrollImage.getBoundingClientRect().bottom ) {
-                    // Scroll default or scroll to bottom of current image
+                // Is the target image top within view ? then scroll to the top of it
+                if (targetScrollImage.getBoundingClientRect().top > 1 ) {
+                    // Scroll to it
+                    targetScrollImage.scrollIntoView({ 
+                        behavior: 'smooth' 
+                    });
+                }
+                // Do we stay within target ? (bottom is further than current view)
+                else if (window.innerHeight +1 < targetScrollImage.getBoundingClientRect().bottom ){
                     this.$.container.scrollBy({ 
-                        top: Math.min(defaultDistance,currentScrollImage.getBoundingClientRect().bottom-window.innerHeight),
+                        top: Math.min(defaultDistance,targetScrollImage.getBoundingClientRect().bottom-window.innerHeight),
                         left: 0, 
                         behavior: 'smooth' 
                     });
-                } else {
+                }
+                // We have to try to get to next image
+                else {
                     // Find next image
-                    let nextScrollImage = currentScrollImage.nextElementSibling;
-                    if (nextScrollImage) {
-                        // Scroll to it
-                        nextScrollImage.scrollIntoView({ 
-                            behavior: 'smooth' 
-                        });
-                    }
+                    let nextScrollImage = targetScrollImage.nextElementSibling;
+                    // Scroll to it
+                    nextScrollImage.scrollIntoView({ 
+                        behavior: 'smooth' 
+                    });
                 }
             }
+
         }
+
         window.customElements.define( HakunekoPages.is, HakunekoPages );
         
         function scrollSmoothly(element, distance) {


### PR DESCRIPTION
Code from PR #1886 reorganised to handle multiple images on screen (manwha with a lot of cuts). Use-cases described in image :
![MagicScroll](https://user-images.githubusercontent.com/19878135/87262099-f2843a80-c4b8-11ea-91f9-dd7545456471.png)

Introduced the first elements for the AutoNextChapter feature : 
- When reaching the bottom page and trying to go to the next image will display (todo) a notice that you have to press the MagicScroll shortcut again
- Pressing it again within 4s will trigger the next chapter function