### PR TITLE
AutoNextChapter pixel-perfect sensitivity

### DIFF
--- a/src/web/lib/hakuneko/frontend@classic-dark/pages.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/pages.html
@@ -535,7 +535,7 @@
             scrollMagic(defaultDistance) {
                 let images = this.$.container.querySelectorAll('.image');
                 // Are we at the end of the page
-                if(images[images.length-1].getBoundingClientRect().bottom-window.innerHeight < 0)
+                if(images[images.length-1].getBoundingClientRect().bottom-window.innerHeight < 1)
                 {
                     // Should we go to next chapter because we previouysly reached the end of page ?
                     if (this.autoNextChapter) { return this.requestChapterUp(); };

--- a/src/web/lib/hakuneko/frontend@classic-light/pages.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/pages.html
@@ -535,7 +535,7 @@
              scrollMagic(defaultDistance) {
                 let images = this.$.container.querySelectorAll('.image');
                 // Are we at the end of the page
-                if(images[images.length-1].getBoundingClientRect().bottom-window.innerHeight < 0)
+                if(images[images.length-1].getBoundingClientRect().bottom-window.innerHeight < 1)
                 {
                     // Should we go to next chapter because we previouysly reached the end of page ?
                     if (this.autoNextChapter) { return this.requestChapterUp(); };


### PR DESCRIPTION
Fixes #2078 

Tech details:
In some cases, the bottom property might return a float that is still positiv  and not trigger the scroll by 1 pix and therefore will not trigger the condition for next page.
Did fix it on a previous condition, forgot to put it in the new one.