### PR TITLE
Added Throttle for ManHuaGui

### DIFF
--- a/src/web/mjs/connectors/ManHuaGui.mjs
+++ b/src/web/mjs/connectors/ManHuaGui.mjs
@@ -16,8 +16,8 @@ export default class ManHuaGui extends SinMH {
         this.queryChapters = 'div.chapter-list ul li a';
         this.config = {
             throttle: {
-                label: 'Chapter Throttle Requests [ms]',
-                description: 'Enter the timespan in [ms] to delay consecuitive HTTP requests while downloading Chapters.\nThe website may ban your IP for to many consecuitive requests.',
+                label: 'Page Throttle Requests [ms]',
+                description: 'Enter the timespan in [ms] to delay consecuitive HTTP requests while downloading Pages.\nThe website may ban your IP for to many consecuitive requests.',
                 input: 'numeric',
                 min: 500,
                 max: 10000,
@@ -36,7 +36,7 @@ export default class ManHuaGui extends SinMH {
 
     async _getMangas() {
         let mangaList = [];
-        let request = new Request(this.url + this.path, this.requestOptions);
+        let request = new Request(new URL(this.path, this.url), this.requestOptions);
         let data = await this.fetchDOM(request, this.queryMangasPageCount);
         let pageCount = parseInt(new RegExp(this.pathMatch).exec(data[0].href)[1]);
         for(let page = 1; page <= pageCount; page++) {

--- a/src/web/mjs/connectors/ManHuaGui.mjs
+++ b/src/web/mjs/connectors/ManHuaGui.mjs
@@ -14,6 +14,37 @@ export default class ManHuaGui extends SinMH {
         this.pathMatch = '/list/index_p(\\d+).html';
         this.queryMangasPageCount = 'div.pager-cont div.pager a:last-of-type';
         this.queryChapters = 'div.chapter-list ul li a';
+        this.config = {
+            throttle: {
+                label: 'Chapter Throttle Requests [ms]',
+                description: 'Enter the timespan in [ms] to delay consecuitive HTTP requests while downloading Chapters.\nThe website may ban your IP for to many consecuitive requests.',
+                input: 'numeric',
+                min: 500,
+                max: 10000,
+                value: 2500
+            },
+            delaylist: {
+                label: 'Delay Manga List Requsts[ms]',
+                description: 'Enter the timespan in [ms] to delay consecuitive HTTP requests while loading MangaList.\nThe website may ban your IP for to many consecuitive requests.',
+                input: 'numeric',
+                min: 500,
+                max: 10000,
+                value: 4500
+            }
+        };
+    }
+
+    async _getMangas() {
+        let mangaList = [];
+        let request = new Request(this.url + this.path, this.requestOptions);
+        let data = await this.fetchDOM(request, this.queryMangasPageCount);
+        let pageCount = parseInt(new RegExp(this.pathMatch).exec(data[0].href)[1]);
+        for(let page = 1; page <= pageCount; page++) {
+            await this.wait(this.config.delaylist.value);
+            let mangas = await this._getMangasFromPage(page);
+            mangaList.push(...mangas);
+        }
+        return mangaList;
     }
 
     async _getChapters(manga) {


### PR DESCRIPTION
Fixes #2059 

NOTE: There are 2 different throttle values because, I couldn't confirm if the throttling is required while downloading chapters or not (Maybe because my internet isn't that fast)... But, according to the Author of the issue, it is required as they got blocked while downloading chapters... So, I assume only small amount of throttling (1500 is a guess.. I couldn't test it..) is required compared to the 4500ms throttling required while syncing MangaList...