### PR TITLE
[MangaHere][MangaFox] Remove ad on last page

### DIFF
--- a/src/web/mjs/connectors/MangaFox.mjs
+++ b/src/web/mjs/connectors/MangaFox.mjs
@@ -101,7 +101,21 @@ export default class MangaFox extends Connector {
     async _getPagesDesktop(chapter) {
         let uri = new URL(chapter.id, this.url);
         let request = new Request(uri, this.requestOptions);
-        return Engine.Request.fetchUI(request, this.script);
+
+        var pages = await Engine.Request.fetchUI(request, this.script);
+        //Get Meta informations from last Image
+        let lastImage = await new Promise(resolve => {
+            const img = new Image();
+            img.onload = function() {
+                resolve(img);
+            };
+            img.src = pages[pages.length-1];
+        });
+        //Check if the last image seems to be the usual ad
+        if(lastImage.naturalHeight==563 && lastImage.naturalWidth==1000) {
+            pages.pop();
+        }
+        return pages;
     }
 
     async _getPageListMobile(chapter) {

--- a/src/web/mjs/connectors/MangaFox.mjs
+++ b/src/web/mjs/connectors/MangaFox.mjs
@@ -109,7 +109,7 @@ export default class MangaFox extends Connector {
             img.onload = function() {
                 resolve(img);
             };
-            img.src = pages[pages.length-1];
+            img.src = pages.slice(-1);
         });
         //Check if the last image seems to be the usual ad
         if(lastImage.naturalHeight===563 && lastImage.naturalWidth===1000) {

--- a/src/web/mjs/connectors/MangaFox.mjs
+++ b/src/web/mjs/connectors/MangaFox.mjs
@@ -102,7 +102,7 @@ export default class MangaFox extends Connector {
         let uri = new URL(chapter.id, this.url);
         let request = new Request(uri, this.requestOptions);
 
-        var pages = await Engine.Request.fetchUI(request, this.script);
+        let pages = await Engine.Request.fetchUI(request, this.script);
         //Get Meta informations from last Image
         let lastImage = await new Promise(resolve => {
             const img = new Image();
@@ -112,7 +112,7 @@ export default class MangaFox extends Connector {
             img.src = pages[pages.length-1];
         });
         //Check if the last image seems to be the usual ad
-        if(lastImage.naturalHeight==563 && lastImage.naturalWidth==1000) {
+        if(lastImage.naturalHeight===563 && lastImage.naturalWidth===1000) {
             pages.pop();
         }
         return pages;


### PR DESCRIPTION
Rework #1543
Detects if the last image seems to be a global included ad by its format Height=563 lWidth==1000
Edge case, the last image is actually this size (low probability as the site is almost always including this ad).

Previous PR found a pattern in the image names but i couldn't find a good solution to detect it.