### PR TITLE
FIX: Disable the right panel when reader disabled

### DIFF
--- a/src/web/lib/hakuneko/frontend@classic-dark/app.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/app.html
@@ -123,7 +123,7 @@
             </div>
             <hakuneko-jobs></hakuneko-jobs>
         </div>
-        <div class="content">
+        <div style$="[[ getContentPanelStyle(readerEnabled) ]]" class="content">
             <hakuneko-start style$="[[ getStartPanelStyle(readerEnabled,chapter) ]]"></hakuneko-start>
             <hakuneko-pages style$="[[ getPagePanelStyle(readerEnabled,chapter) ]]" selected-chapter="[[ chapter ]]" selected-media="{{ selectedMediaIndex }}"></hakuneko-pages>
         </div>
@@ -174,6 +174,13 @@
             /**
              *
              */
+             getContentPanelStyle(readerEnabled) {
+                return ( readerEnabled ? '' : 'display: none;' );
+            }
+
+            /**
+             *
+             */
             getPagePanelStyle(readerEnabled,chapter) {
                 return ( !readerEnabled || chapter===undefined ? 'display: none;' : '' );
             }
@@ -182,7 +189,7 @@
              *
              */
              getStartPanelStyle(readerEnabled,chapter) {
-                return ( !readerEnabled || chapter!==undefined ? 'display: none;' : '' );
+                return ( chapter!==undefined ? 'display: none;' : '' );
             }
 
             /**

--- a/src/web/lib/hakuneko/frontend@classic-dark/start.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/start.html
@@ -11,11 +11,12 @@
                 width: calc(100% - 2em);
                 height: calc(100% - 2em);
                 padding: 1em;
-                background-color: var(--page-control-background-color);
+                background-color: var(--page-reader-background-color);
                 background-image: var(--page-background-image);
+                overflow-y: scroll;
                 background-size: cover;
-                background-attachment: scroll;
-                user-select: none;
+                background-repeat: no-repeat;
+                background-position: left top;
                 font-size: 1.25em;
                 
             }

--- a/src/web/lib/hakuneko/frontend@classic-light/app.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/app.html
@@ -125,7 +125,7 @@
             </div>
             <hakuneko-jobs></hakuneko-jobs>
         </div>
-        <div class="content">
+        <div style$="[[ getContentPanelStyle(readerEnabled) ]]" class="content">
             <hakuneko-start style$="[[ getStartPanelStyle(readerEnabled,chapter) ]]"></hakuneko-start>
             <hakuneko-pages style$="[[ getPagePanelStyle(readerEnabled,chapter) ]]" selected-chapter="[[ chapter ]]" selected-media="{{ selectedMediaIndex }}"></hakuneko-pages>
         </div>
@@ -171,6 +171,13 @@
              */
             getChapterListStyle(readerEnabled) {
                 return ( readerEnabled ? 'width: 20em;' : 'flex: 1; max-width: 50%;' );
+            }
+
+            /**
+             *
+             */
+             getContentPanelStyle(readerEnabled) {
+                return ( readerEnabled ? '' : 'display: none;' );
             }
 
             /**

--- a/src/web/lib/hakuneko/frontend@classic-light/start.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/start.html
@@ -11,11 +11,12 @@
                 width: calc(100% - 2em);
                 height: calc(100% - 2em);
                 padding: 1em;
-                background-color: var(--page-control-background-color);
+                background-color: var(--page-reader-background-color);
                 background-image: var(--page-background-image);
+                overflow-y: scroll;
                 background-size: cover;
-                background-attachment: scroll;
-                user-select: none;
+                background-repeat: no-repeat;
+                background-position: left top;
                 font-size: 1.25em;
                 
             }


### PR DESCRIPTION
Adding the start page introduced a regression in the interface: the right panel isn't removed when "Enable Reader" option was disabled and therefore creating a UI behavior issue.
The start page will only be displayed when "Enable Reader" is enabled (default hakuneko configuration).  Fits with the purpose of the start page: help new users.