### PR TITLE
information mark on menu description

### DIFF
--- a/src/web/lib/hakuneko/frontend@classic-dark/menu.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/menu.html
@@ -197,10 +197,10 @@
                         <template is="dom-repeat" items="[[ item.settings ]]">
                             <tr>
                                 <td width="1">
-                                    <label title="[[ item.description ]]">[[ item.label ]]</label>
+                                    <label title="[[ item.description ]]"><i class="fas fa-fw fa-info-circle"></i> [[ item.label ]] </label>
                                 </td>
                                 <td>
-                                    <hakuneko-input item="{{ item }}"></hakuneko-input>
+                                    <hakuneko-input item="{{ item }}"></hakuneko-input> 
                                 </td>
                             </tr>
                         </template>

--- a/src/web/lib/hakuneko/frontend@classic-light/menu.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/menu.html
@@ -197,7 +197,7 @@
                         <template is="dom-repeat" items="[[ item.settings ]]">
                             <tr>
                                 <td width="1">
-                                    <label title="[[ item.description ]]">[[ item.label ]]</label>
+                                    <label title="[[ item.description ]]"><i class="fas fa-fw fa-info-circle"></i> [[ item.label ]]</label>
                                 </td>
                                 <td>
                                     <hakuneko-input item="{{ item }}"></hakuneko-input>


### PR DESCRIPTION
Solves #2240 

Tested different icon on different position. Ended up with info-circle on the left
Open for debate.

![hn-menu-icon-label](https://user-images.githubusercontent.com/19878135/93247048-fd479e00-f78d-11ea-950b-babfd102bee3.png)