### PR TITLE
FIX UI overflow when titles are long

### DIFF
--- a/src/web/lib/hakuneko/frontend@classic-dark/app.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/app.html
@@ -21,7 +21,7 @@
             }
             .control {
                 flex-direction: column;
-                width: 100%;
+                width: calc(100% - 1px);
                 height: 100%;
                 flex: 1;
                 border-right: var(--app-control-border);
@@ -57,6 +57,12 @@
             hakuneko-menu {
                 flex: 0;
                 -webkit-app-region: drag;
+            }
+            hakuneko-mangas {
+                box-sizing: border-box;
+            }
+            hakuneko-chapters {
+                box-sizing: border-box;
             }
             hakuneko-jobs {
                 flex: 0;

--- a/src/web/lib/hakuneko/frontend@classic-light/app.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/app.html
@@ -21,7 +21,7 @@
             }
             .control {
                 flex-direction: column;
-                width: 100%;
+                width: calc(100% - 1px);
                 height: 100%;
                 flex: 1;
                 border-right: var(--app-control-border);
@@ -58,6 +58,12 @@
             hakuneko-menu {
                 flex: 0;
                 -webkit-app-region: drag;
+            }
+            hakuneko-mangas {
+                box-sizing: border-box;
+            }
+            hakuneko-chapters {
+                box-sizing: border-box;
             }
             hakuneko-jobs {
                 flex: 0;


### PR DESCRIPTION
Fixes #2328 
Issue was with the max-width (50%) attributes not being correctly handled in the mangas & chapters module.
box-sizing: border-box; allows to get it working (thanks stackoverflow).
Removed 1px from the width because sometimes a border margin seems to appear (when scaling, then it's possibly a flex calculation rounding issue?) and then an elevator appears on bottom. This "hack" seems to bypass this issue (if someone has a better idea ... )