### PR TITLE
fetchUI should block images by default

### DIFF
--- a/src/web/mjs/engine/Request.mjs
+++ b/src/web/mjs/engine/Request.mjs
@@ -327,7 +327,7 @@ export default class Request {
                 webPreferences: {
                     nodeIntegration: false,
                     webSecurity: false,
-                    images: images
+                    images: images || false
                 }
             } );
             //win.webContents.openDevTools();


### PR DESCRIPTION
Revert 70df339 ([default image loading](https://github.com/manga-download/hakuneko/commit/70df339#diff-ebab5841914b1b97937f058e156b0d4c00f9a9a0355e57a3207bfa817cbdca61L120)), which accidentally enables image loading in fetchUI