### PR TITLE
[asurascans] ignore fake images

### DIFF
--- a/src/web/mjs/connectors/AsuraScans.mjs
+++ b/src/web/mjs/connectors/AsuraScans.mjs
@@ -11,5 +11,6 @@ export default class AsuraScans extends WordPressMangastream {
         this.path = '/manga/';
 
         this.queryMangas = 'div#content div.postbody div.listupd div.bs div.bsx a';
+        this.queryPages = 'div#readerarea img[loading]';
     }
 }


### PR DESCRIPTION
Not an issue right now in HakuNeko (images are provided by JS variable), but just to be future safe...
References: dazedcat19/FMD2#184