### PR TITLE
[takeshobo] fix chapter list

### DIFF
--- a/src/web/mjs/connectors/templates/SpeedBinb.mjs
+++ b/src/web/mjs/connectors/templates/SpeedBinb.mjs
@@ -33,9 +33,10 @@ export default class SpeedBinb extends Connector {
                 }
                 let imageConfigurtions = data.querySelectorAll( 'div[data-ptimg$="ptimg.json"]' );
                 if( imageConfigurtions.length > 0 ) {
+                    // TODO: Use the response URL instead of the request URL (in case of redirection ...)
                     return this._getPageList_v016061( [...imageConfigurtions], request.url );
                 }
-                //
+
                 throw new Error( 'Unsupported version of SpeedBinb reader!' );
             } )
             .then( pageList => callback( null, pageList ) )

--- a/src/web/mjs/connectors/templates/TakeShobo.mjs
+++ b/src/web/mjs/connectors/templates/TakeShobo.mjs
@@ -41,8 +41,13 @@ export default class TakeShobo extends SpeedBinb {
         let request = new Request(new URL(manga.id, this.url), this.requestOptions);
         let data = await this.fetchDOM(request, this.queryChapters);
         return data.filter(element => element.querySelector(this.queryChaptersLink)).map(element => {
+            // NOTE: In some cases the chapter is redirected to an URL correctly ending with a '/'
+            //       When using the URL without the ending '/', the SpeedBin template may produce a wrong base URL,
+            //       which will lead to 404 errors when acquiring the images
+            let id = this.getRootRelativeOrAbsoluteLink(element.querySelector(this.queryChaptersLink), request.url);
+            id += id.endsWith('/') ? '' : '/';
             return {
-                id: this.getRootRelativeOrAbsoluteLink(element.querySelector(this.queryChaptersLink), request.url),
+                id: id,
                 title: element.querySelector(this.queryChaptersTitle).innerText.replace(manga.title, '').trim(),
                 language: ''
             };

--- a/src/web/mjs/connectors/templates/TakeShobo.mjs
+++ b/src/web/mjs/connectors/templates/TakeShobo.mjs
@@ -48,10 +48,4 @@ export default class TakeShobo extends SpeedBinb {
             };
         });
     }
-
-    // TODO: some images can not be downloaded, e.g. from:
-    // Manga:   https://storia.takeshobo.co.jp/manga/yomikiri-dash/
-    // Chapter: https://storia.takeshobo.co.jp/manga/yomikiri-dash/_files_ecstasy/ecstasy/
-    // Uses:    https://storia.takeshobo.co.jp/manga/yomikiri-dash/_files_ecstasy/data/0001.ptimg.json
-    // Correct: https://storia.takeshobo.co.jp/manga/yomikiri-dash/_files_ecstasy/ecstasy/data/0001.ptimg.json
 }

--- a/src/web/mjs/connectors/templates/TakeShobo.mjs
+++ b/src/web/mjs/connectors/templates/TakeShobo.mjs
@@ -48,4 +48,10 @@ export default class TakeShobo extends SpeedBinb {
             };
         });
     }
+
+    // TODO: some images can not be downloaded, e.g. from:
+    // Manga:   https://storia.takeshobo.co.jp/manga/yomikiri-dash/
+    // Chapter: https://storia.takeshobo.co.jp/manga/yomikiri-dash/_files_ecstasy/ecstasy/
+    // Uses:    https://storia.takeshobo.co.jp/manga/yomikiri-dash/_files_ecstasy/data/0001.ptimg.json
+    // Correct: https://storia.takeshobo.co.jp/manga/yomikiri-dash/_files_ecstasy/ecstasy/data/0001.ptimg.json
 }

--- a/src/web/mjs/connectors/templates/TakeShobo.mjs
+++ b/src/web/mjs/connectors/templates/TakeShobo.mjs
@@ -40,7 +40,7 @@ export default class TakeShobo extends SpeedBinb {
     async _getChapters(manga) {
         let request = new Request(new URL(manga.id, this.url), this.requestOptions);
         let data = await this.fetchDOM(request, this.queryChapters);
-        return data.map(element => {
+        return data.filter(element => element.querySelector(this.queryChaptersLink)).map(element => {
             return {
                 id: this.getRootRelativeOrAbsoluteLink(element.querySelector(this.queryChaptersLink), request.url),
                 title: element.querySelector(this.queryChaptersTitle).innerText.replace(manga.title, '').trim(),


### PR DESCRIPTION
- Filter chapters without a valid link (non-purchased chapters)
- Some chapter links are not ending with `/` and are redirected to the URL correctly ending with `/`, which leads to problems in SpeedBinb when composing the image links based on the original chapter URL without the trailing `/`