### PR TITLE
Add throttling when downloading packets from HLS video

### DIFF
--- a/src/web/mjs/connectors/AnimePahe.mjs
+++ b/src/web/mjs/connectors/AnimePahe.mjs
@@ -22,6 +22,14 @@ export default class AnimePahe extends Connector {
                     { value: '1080', name: '1080p' }
                 ],
                 value: ''
+            },
+            throttle: {
+                label: 'Video Stream Throttle [ms]',
+                description: 'Enter the timespan in [ms] to delay consecuitive HTTP requests while downloading packets from the video stream.\nThe download may fail if there are too many packets requested within a certain interval.',
+                input: 'numeric',
+                min: 100,
+                max: 10000,
+                value: 1000
             }
         };
     }

--- a/src/web/mjs/connectors/NineAnime.mjs
+++ b/src/web/mjs/connectors/NineAnime.mjs
@@ -29,6 +29,14 @@ export default class NineAnime extends Connector {
                     { value: '1080', name: '1080p' }
                 ],
                 value: ''
+            },
+            throttle: {
+                label: 'Video Stream Throttle [ms]',
+                description: 'Enter the timespan in [ms] to delay consecuitive HTTP requests while downloading packets from the video stream.\nThe download may fail if there are too many packets requested within a certain interval.',
+                input: 'numeric',
+                min: 100,
+                max: 10000,
+                value: 1000
             }
         };
     }


### PR DESCRIPTION
Some streaming servers play dirty and will refuse to serve data when there are too many concurrent requests within a certain interval.