### PR TITLE
fix queensmanga

### DIFF
--- a/src/web/mjs/connectors/QueensManga.mjs
+++ b/src/web/mjs/connectors/QueensManga.mjs
@@ -1,12 +1,12 @@
-import WordPressMadara from './templates/WordPressMadara.mjs';
+import WordPressMadaraNovel from './templates/WordPressMadaraNovel.mjs';
 
-export default class QueensManga extends WordPressMadara {
+export default class QueensManga extends WordPressMadaraNovel {
 
     constructor() {
         super();
         super.id = 'queensmanga';
         super.label = 'ملكات المانجا (Queens Manga)';
-        this.tags = [ 'webtoon', 'arabic' ];
+        this.tags = ['webtoon', 'arabic'];
         this.url = 'https://queensmanga.com';
     }
 }

--- a/src/web/mjs/connectors/templates/WordPressMadara.mjs
+++ b/src/web/mjs/connectors/templates/WordPressMadara.mjs
@@ -91,8 +91,7 @@ export default class WordPressMadara extends Connector {
         let data = await this.fetchDOM(request, this.queryPages);
         return data.map(element => {
             if (element.src.includes('data:image')) {
-                const data = element.src.split(',').pop();
-                return this._mapDataUriType(data) + data;
+                return element.src.match(/data:image[^\s'"]*/)[0];
             } else {
                 return this.createConnectorURI({
                     // HACK: bypass 'i0.wp.com' image CDN to ensure original images are loaded directly from host
@@ -120,15 +119,5 @@ export default class WordPressMadara extends Connector {
         const element = [...data].pop();
         const title = (element.content || element.textContent).trim();
         return new Manga(this, uri, title);
-    }
-
-    _mapDataUriType(signature) {
-        if (signature.startsWith('/9j/4AA')) {
-            return 'data:image/jpeg;base64,';
-        }
-        if (signature.startsWith('iVBORw0')) {
-            return 'data:image/png;base64,';
-        }
-        return 'data:application/octet-stream;base64,';
     }
 }


### PR DESCRIPTION
if ships the page with the `data:image/jpg;base64,'image data'`
format
(way of dealing with it ripped from mangaship)

connector also has novels so changed to MadaraNovel template
resolves #2943