### PR TITLE
use mobile site for kuaikanmanhua for larger images.

### DIFF
--- a/src/web/mjs/connectors/kuaikanmanhua.mjs
+++ b/src/web/mjs/connectors/kuaikanmanhua.mjs
@@ -78,8 +78,6 @@ export default class Kuaikanmanhua extends Connector {
     }
 
     async _getPageList(manga, chapter, callback) {
-        // clone header, then set mobile user-agent.
-        // mobile site gives larger (1280px wide) images, while desktop site returns smaller (750px) images.
         let newRequestOptions = Object.assign({}, this.requestOptions);
         newRequestOptions.headers.set(
             'x-user-agent',

--- a/src/web/mjs/connectors/kuaikanmanhua.mjs
+++ b/src/web/mjs/connectors/kuaikanmanhua.mjs
@@ -1,7 +1,7 @@
 import Connector from '../engine/Connector.mjs';
 import Manga from '../engine/Manga.mjs';
 
-export default class Kauikanmanhua extends Connector {
+export default class Kuaikanmanhua extends Connector {
 
     constructor() {
         super();
@@ -78,13 +78,21 @@ export default class Kauikanmanhua extends Connector {
     }
 
     async _getPageList(manga, chapter, callback) {
+        // clone header, then set mobile user-agent.
+        // mobile site gives larger (1280px wide) images, while desktop site returns smaller (750px) images.
+        let newRequestOptions = Object.assign({}, this.requestOptions);
+        newRequestOptions.headers.set(
+            'x-user-agent',
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1'
+        );
+
         try {
             let script = `
             new Promise(resolve => {
-                let pages = __NUXT__.data[0].comicInfo.comicImages.map(img => img.url);
+                let pages = __NUXT__.data[0].comicInfo.comic_images.map(img => img.url);
                 resolve(pages);
             });`;
-            let request = new Request(this.url + chapter.id, this.requestOptions);
+            let request = new Request(this.url + chapter.id, newRequestOptions);
             let pageList = await Engine.Request.fetchUI(request, script);
             callback(null, pageList);
         } catch (error) {


### PR DESCRIPTION
**tl;dr.** mobile site gives bigger images. bigger images makes me happy.

**context.** a friend of mine recently tipped me off that kuaikanmanhua serves two different image sizes - 750px wide for the desktop site and 1280px wide for the mobile site. from a scanlation perspective, i prefer high-quality images whenever they're available.

i've tested these changes locally and i believe these are the only changes that need to be made. faking a mobile user-agent will redirect to the mobile site, and then the data structure is slightly different (`comicImages` vs. `comic_images`).