### PR TITLE
Disable installation of NPM package that requires compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "win-7zip": "latest"
   },
   "scripts": {
-    "postinstall": "cd src/app && npm install",
+    "postinstall": "cd src/app && npm install --legacy-peer-deps",
     "start": "npm run start:dev",
     "start:dev": "electron . --update-url=DISABLED --cache-directory=./src/web --disable-http-cache",
     "start:build": "npm run build:web && electron . --update-url=DISABLED --cache-directory=./build/latest",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "win-7zip": "latest"
   },
   "scripts": {
-    "postinstall": "cd src/app && npm install --legacy-peer-deps",
+    "postinstall": "cd src/app && npm install --no-optional",
     "start": "npm run start:dev",
     "start:dev": "electron . --update-url=DISABLED --cache-directory=./src/web --disable-http-cache",
     "start:build": "npm run build:web && electron . --update-url=DISABLED --cache-directory=./build/latest",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -11,8 +11,8 @@
   "main": "main.js",
   "dependencies": {
     "@logtrine/logtrine": "latest",
+    "discord-rpc": "^3.2.0",
     "fs-extra": "latest",
-    "jszip": "latest",
-    "discord-rpc": "^3.1.1"
+    "jszip": "latest"
   }
 }


### PR DESCRIPTION
The `discord-rpc@3.1.4` package had a peer dependency to `register-schemes`.
Before NPM 7, peer dependencies were not installed, this changed in NPM 7 and they are installed automatically.
Unfortunately the package `register-schemes` requires to be compiled during installation (python, vs-toolchain, ...).
=> The developer got many errors when installing dependencies with NPM > 7.

This PR updates `discord-rpc` to 3.2.0 which has changed `register-schemes` to be an optional dependency instead of a peer dependency, therefore this stupid package is no longer installed automatically when using NPM > 7