### PR TITLE
Adding number of retries setting to retry on fetchDOM fail

### DIFF
--- a/src/web/mjs/engine/Connector.mjs
+++ b/src/web/mjs/engine/Connector.mjs
@@ -445,15 +445,16 @@ export default class Connector {
         if((response == null || response.status >= 500) && retries > 0) {
             await this.wait(2500);
             return this.fetchDOM(request, selector, retries - 1);
-        } else if (response != null ) {
-            const content = response.headers.get('content-type');
-            if(response.status === 200 || content.includes('text/html')) {
-                const data = await response.arrayBuffer();
-                const dom = this.createDOM(new TextDecoder(encoding || 'utf8').decode(data));
-                return Promise.resolve(!selector ? dom : [...dom.querySelectorAll(selector)]);
-            }
+        } else if (response == null ) {
+            throw new Error(`Failed to receive content from "${request.url}"`);
         }
 
+        const content = response.headers.get('content-type');
+        if(response.status === 200 || content.includes('text/html')) {
+            const data = await response.arrayBuffer();
+            const dom = this.createDOM(new TextDecoder(encoding || 'utf8').decode(data));
+            return Promise.resolve(!selector ? dom : [...dom.querySelectorAll(selector)]);
+        }
         throw new Error(`Failed to receive content from "${request.url}" (type: ${content}, status: ${response.status}) - ${response.statusText}`);
     }
 

--- a/src/web/mjs/engine/Connector.mjs
+++ b/src/web/mjs/engine/Connector.mjs
@@ -23,7 +23,7 @@ export default class Connector {
         //
         this.existingMangas = [];
         // retries for fetch
-        this.retries = 3
+        this.retries = 3;
         /*
          * initialize the default request options
          * these request options will also be used for download jobs (image/media stream downloads)
@@ -57,7 +57,7 @@ export default class Connector {
      */
     async _initializeConnector() {
         let uri = new URL(this.url);
-        this.retries = parseInt(Engine.Settings.retries.value) || this.retries
+        this.retries = parseInt(Engine.Settings.retries.value) || this.retries;
         let request = new Request(uri.href, this.requestOptions);
         return Engine.Request.fetchUI(request, '');
     }
@@ -435,10 +435,12 @@ export default class Connector {
             request = new Request(request.href, this.requestOptions);
         }
 
-        let response = null
+        let response = null;
         try {
             response = await fetch(request.clone());
-        } catch {}
+        } catch(e) {
+            console.warn(`failed to fetch ${request.url} retrying..., retries left: ${retries}`);
+        }
 
         if((response == null || response.status >= 500) && retries > 0) {
             await this.wait(2500);

--- a/src/web/mjs/engine/Settings.mjs
+++ b/src/web/mjs/engine/Settings.mjs
@@ -93,6 +93,13 @@ export default class Settings extends EventTarget {
             value: false
         };
 
+        this.retries = {
+            label: 'Retries',
+            description: 'No of times to retry if the site fetch failes',
+            input: types.numeric,
+            value: 3
+        }
+
         this.chapterTitleFormat = {
             label: 'Chapter Title Format',
             description: [

--- a/src/web/mjs/engine/Settings.mjs
+++ b/src/web/mjs/engine/Settings.mjs
@@ -98,7 +98,7 @@ export default class Settings extends EventTarget {
             description: 'No of times to retry if the site fetch failes',
             input: types.numeric,
             value: 3
-        }
+        };
 
         this.chapterTitleFormat = {
             label: 'Chapter Title Format',


### PR DESCRIPTION
**Issue**: When getting mangas from large sites like manganel, mangakakalot and others the fetch sometime fails after fetching like 100 or so pages. 
To fix the above issue, adding `Retries` setting to retry on fetch fails in dom. Had to add try/catch as the fetch sometimes fails with null excetion which is not captured by `await`