### PR TITLE
[sekaikomik] initialize all CloudFlare protected paths

### DIFF
--- a/src/web/mjs/connectors/SekaiKomik.mjs
+++ b/src/web/mjs/connectors/SekaiKomik.mjs
@@ -10,4 +10,13 @@ export default class SekaiKomik extends WordPressMangastream {
         this.url = 'https://www.sekaikomik.club';
         this.path = '/daftar-komik/?list';
     }
+
+    async _initializeConnector() {
+        const paths = [ '/', '/manga/' ];
+        for(let path of paths) {
+            const uri = new URL(path, this.url);
+            const request = new Request(uri, this.requestOptions);
+            await Engine.Request.fetchUI(request, '', 25000, true);
+        }
+    }
 }


### PR DESCRIPTION
References: #3330 
This PR will only add CloudFlare initialization for the `/manga/` URL pattern, loading chapters will still fail due to #2933