### PR TITLE
Add more filter combinations to MangaDex connector in order to get entire list

### DIFF
--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -57,14 +57,28 @@ export default class MangaDex extends Connector {
         let mangaList = [];
         // NOTE: Due to a limit of 10k results, it is necessary to permutate some filters in order to get as many results as possible
         const queries = [
-            { status: 'ongoing', order: 'asc' },
-            { status: 'ongoing', order: 'desc' },
-            { status: 'completed', order: 'asc' },
-            { status: 'completed', order: 'desc' },
-            { status: 'hiatus', order: 'asc' },
-            { status: 'hiatus', order: 'desc' },
-            { status: 'cancelled', order: 'asc' },
-            { status: 'cancelled', order: 'desc' }
+            { status: ['ongoing'], order: 'asc', publicationDemographic: ['none'],
+			  contentRating: ['none','safe','suggestive','erotica','pornographic'] },
+            { status: ['ongoing'], order: 'asc', publicationDemographic: ['shounen', 'shoujo', 'josei', 'seinen'],
+			  contentRating: ['safe','suggestive','erotica','pornographic'] },
+            { status: ['completed'], order: 'asc', publicationDemographic: ['none'],
+			  contentRating: ['safe'] },
+            { status: ['completed'], order: 'desc', publicationDemographic: ['none'],
+			  contentRating: ['safe'] },
+            { status: ['completed'], order: 'asc', publicationDemographic: ['shounen'],
+			  contentRating: ['safe'] },
+            { status: ['completed'], order: 'asc', publicationDemographic: ['shoujo'],
+			  contentRating: ['safe'] },
+            { status: ['completed'], order: 'asc', publicationDemographic: ['josei', 'seinen'],
+			  contentRating: ['safe'] },
+            { status: ['completed'], order: 'asc', publicationDemographic: ['none'],
+			  contentRating: ['pornographic'] },
+            { status: ['completed'], order: 'asc', publicationDemographic: ['shounen', 'shoujo', 'josei', 'seinen'],
+			  contentRating: ['pornographic'] },
+            { status: ['completed'], order: 'asc', publicationDemographic: [],
+			  contentRating: ['suggestive','erotica'] },
+            { status: ['hiatus', 'cancelled'], order: 'asc', publicationDemographic: [],
+			  contentRating: ['safe','suggestive','erotica','pornographic'] }
         ];
         for(let query of queries) {
             for(let page = 0, run = true; run; page++) {
@@ -86,13 +100,16 @@ export default class MangaDex extends Connector {
         const uri = new URL('/manga', this.api);
         uri.searchParams.set('limit', 100);
         uri.searchParams.set('offset', 100 * page);
-        uri.searchParams.set('status[]', query.status);
+		for (const queryStatus of query.status) {
+			uri.searchParams.append('status[]', queryStatus);
+		}
         uri.searchParams.set('order[createdAt]', query.order);
-        uri.searchParams.append('contentRating[]', 'none');
-        uri.searchParams.append('contentRating[]', 'safe');
-        uri.searchParams.append('contentRating[]', 'suggestive');
-        uri.searchParams.append('contentRating[]', 'erotica');
-        uri.searchParams.append('contentRating[]', 'pornographic');
+		for (const queryContentRating of query.contentRating) {
+			uri.searchParams.append('contentRating[]', queryContentRating);
+		}
+		for (const queryPublicationDemographic of query.publicationDemographic) {
+			uri.searchParams.append('publicationDemographic[]', queryPublicationDemographic);
+		}
         const request = new Request(uri, this.requestOptions);
         const data = await this.fetchJSON(request, 3);
         return !data.results ? [] : data.results.map(result => {

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -58,27 +58,27 @@ export default class MangaDex extends Connector {
         // NOTE: Due to a limit of 10k results, it is necessary to permutate some filters in order to get as many results as possible
         const queries = [
             { status: ['ongoing'], order: 'asc', publicationDemographic: ['none'],
-			  contentRating: ['none','safe','suggestive','erotica','pornographic'] },
+              contentRating: ['none','safe','suggestive','erotica','pornographic'] },
             { status: ['ongoing'], order: 'asc', publicationDemographic: ['shounen', 'shoujo', 'josei', 'seinen'],
-			  contentRating: ['safe','suggestive','erotica','pornographic'] },
+              contentRating: ['safe','suggestive','erotica','pornographic'] },
             { status: ['completed'], order: 'asc', publicationDemographic: ['none'],
-			  contentRating: ['safe'] },
+              contentRating: ['safe'] },
             { status: ['completed'], order: 'desc', publicationDemographic: ['none'],
-			  contentRating: ['safe'] },
+              contentRating: ['safe'] },
             { status: ['completed'], order: 'asc', publicationDemographic: ['shounen'],
-			  contentRating: ['safe'] },
+              contentRating: ['safe'] },
             { status: ['completed'], order: 'asc', publicationDemographic: ['shoujo'],
-			  contentRating: ['safe'] },
+              contentRating: ['safe'] },
             { status: ['completed'], order: 'asc', publicationDemographic: ['josei', 'seinen'],
-			  contentRating: ['safe'] },
+              contentRating: ['safe'] },
             { status: ['completed'], order: 'asc', publicationDemographic: ['none'],
-			  contentRating: ['pornographic'] },
+              contentRating: ['pornographic'] },
             { status: ['completed'], order: 'asc', publicationDemographic: ['shounen', 'shoujo', 'josei', 'seinen'],
-			  contentRating: ['pornographic'] },
+              contentRating: ['pornographic'] },
             { status: ['completed'], order: 'asc', publicationDemographic: [],
-			  contentRating: ['suggestive','erotica'] },
+              contentRating: ['suggestive','erotica'] },
             { status: ['hiatus', 'cancelled'], order: 'asc', publicationDemographic: [],
-			  contentRating: ['safe','suggestive','erotica','pornographic'] }
+              contentRating: ['safe','suggestive','erotica','pornographic'] }
         ];
         for(let query of queries) {
             for(let page = 0, run = true; run; page++) {
@@ -100,16 +100,16 @@ export default class MangaDex extends Connector {
         const uri = new URL('/manga', this.api);
         uri.searchParams.set('limit', 100);
         uri.searchParams.set('offset', 100 * page);
-		for (const queryStatus of query.status) {
-			uri.searchParams.append('status[]', queryStatus);
-		}
+        for (const queryStatus of query.status) {
+            uri.searchParams.append('status[]', queryStatus);
+        }
         uri.searchParams.set('order[createdAt]', query.order);
-		for (const queryContentRating of query.contentRating) {
-			uri.searchParams.append('contentRating[]', queryContentRating);
-		}
-		for (const queryPublicationDemographic of query.publicationDemographic) {
-			uri.searchParams.append('publicationDemographic[]', queryPublicationDemographic);
-		}
+        for (const queryContentRating of query.contentRating) {
+            uri.searchParams.append('contentRating[]', queryContentRating);
+        }
+        for (const queryPublicationDemographic of query.publicationDemographic) {
+            uri.searchParams.append('publicationDemographic[]', queryPublicationDemographic);
+        }
         const request = new Request(uri, this.requestOptions);
         const data = await this.fetchJSON(request, 3);
         return !data.results ? [] : data.results.map(result => {


### PR DESCRIPTION
I removed the asc/desc combinations everywhere I could to avoid duplicates.
The old workaround fetched a total of around 40 thousand manga, now it fetches around 60 thousand. Everything is definitely complete, except the completed/safe/no demographic combination, although I doubt it has over 20 thousand manga in itself.
Some of them are still dangerously close to the 10 thousand limit and could exceed it in a few months or years, so it would be good if someone worked on a complete solution.
The best solution would be to not store the list locally at all, instead fetching it along with the search query every time, but that would require a large overhaul.
A more robust workaround would be to programmatically generate all 80 possible combinations, automatically deciding whether to request the reverse list based on if the returned count is capped at ten thousand.
Or possibly filtering by date created, restricting to a single month for example and looping over all months.