### PR TITLE
fix(connector/9anime): change the _getPages script to avoid clicking

### DIFF
--- a/src/web/mjs/connectors/NineAnime.mjs
+++ b/src/web/mjs/connectors/NineAnime.mjs
@@ -139,23 +139,15 @@ export default class NineAnime extends Connector {
             new Promise((resolve, reject) => {
                 const timer = setInterval(() => {
                     try {
-                        if(button = document.querySelector('ul.episodes li a.active')) {
+                        const iframe = document.querySelector('div#player iframe')
+
+                        if (iframe) {
                             clearInterval(timer);
                             localStorage.setItem('player_autoplay', 0);
                             localStorage.setItem('_lastServerId', ${chapterID.server});
-                            new MutationObserver(mutations => {
-                                for(const mutation of mutations) {
-                                    for(const node of mutation.addedNodes) {
-                                        if(/iframe/i.test(node.tagName)) {
-                                            node.parentNode.removeChild(node);
-                                            resolve(node.src);
-                                        }
-                                    }
-                                }
-                            }).observe(document.querySelector('div#player'), {
-                                childList: true
-                            });
-                            button.click();
+                            resolve(iframe.src)
+                        } else {
+                            window.location.reload()
                         }
                     } catch(error) {
                         reject(error);


### PR DESCRIPTION
I spend a lot of time figuring out why the `button.click()` doesn't do anything. I'm still not sure why, but I change the script and it's working again.

Maybe we can decrease the `setInterval` delay to go faster :thinking: ?
