### PR TITLE
Fix for Sync All comics in Webnovel

### DIFF
--- a/src/web/mjs/connectors/WebNovel.mjs
+++ b/src/web/mjs/connectors/WebNovel.mjs
@@ -30,9 +30,11 @@ export default class WebNovel extends Connector {
 
     _getMangaListFromPages( page ) {
         page = page || 1;
-        let uri = new URL( '/go/pcm/comic/listAjax', this.url );
+        let uri = new URL( '/go/pcm/category/categoryAjax', this.url );
         uri.searchParams.set( 'pageIndex', page );
         uri.searchParams.set( '_csrfToken', this.token );
+        uri.searchParams.set( 'categoryId', 0 );
+        uri.searchParams.set( 'categoryType', 2 );
         let request = new Request( uri.href, this.requestOptions );
         return this.fetchJSON( request )
             .then( data => {


### PR DESCRIPTION
categoryId is categories like Action, Adventure etc
categoryType is Novel, Comic and Fanfic.

fixes #3961

**Currently the lists only return the English titles. Can someone please test this? I compared list in website and it is also not mapping any comic in language other than english.**