### PR TITLE
Option for sequential downloads

### DIFF
--- a/src/web/mjs/engine/DownloadJob.mjs
+++ b/src/web/mjs/engine/DownloadJob.mjs
@@ -105,7 +105,7 @@ export default class DownloadJob extends EventTarget {
 
     async _downloadPages(pages, directory, callback) {
         try {
-            const content = Engine.Settings.useSequentialImageDownloads.value ? await this._downloadPagesSequential(pages) : await this._downloadPagesConcurrent(pages);
+            const content = Engine.Settings.useSequentialMediaDownloads.value ? await this._downloadPagesSequential(pages) : await this._downloadPagesConcurrent(pages);
             await Engine.Storage.saveChapterPages(this.chapter, content);
             this.setProgress(100);
             this.setStatus(statusDefinitions.completed);
@@ -231,7 +231,7 @@ export default class DownloadJob extends EventTarget {
                     this.setProgress(this.progress + 100/packets.length);
                 };
 
-                if(Engine.Settings.useSequentialImageDownloads.value ) {
+                if(Engine.Settings.useSequentialMediaDownloads.value ) {
                     return (async () => {
                         for(let packet of packets) {
                             await packetDownload(packet, this.throttle);

--- a/src/web/mjs/engine/Settings.mjs
+++ b/src/web/mjs/engine/Settings.mjs
@@ -155,7 +155,7 @@ export default class Settings extends EventTarget {
 
         this.useSequentialMediaDownloads = {
             label: 'Disable Concurrent Downloads',
-            description: 'Media will be downloaded one after another instead of concurrently. Enable this in case of holding a slow internet connection, or regualry encountering failed downloads due to network errors.',
+            description: 'Media will be downloaded one after another instead of concurrently. Enable this in case of holding a slow internet connection, or regularly encountering failed downloads due to network errors.',
             input: types.checkbox,
             value: false
         };

--- a/src/web/mjs/engine/Settings.mjs
+++ b/src/web/mjs/engine/Settings.mjs
@@ -153,6 +153,13 @@ export default class Settings extends EventTarget {
             value: 90
         };
 
+        this.useSequentialImageDownloads = {
+            label: 'Disable Concurrent Downloads',
+            description: 'Images will be downloaded one after another instead of concurrently. Enable this in case of slow internet connection, or regualry encountering failed downloads due to network errors.',
+            input: types.checkbox,
+            value: false
+        };
+
         this.proxyRules = {
             label: 'Proxy Rules',
             description: [

--- a/src/web/mjs/engine/Settings.mjs
+++ b/src/web/mjs/engine/Settings.mjs
@@ -153,9 +153,9 @@ export default class Settings extends EventTarget {
             value: 90
         };
 
-        this.useSequentialImageDownloads = {
+        this.useSequentialMediaDownloads = {
             label: 'Disable Concurrent Downloads',
-            description: 'Images will be downloaded one after another instead of concurrently. Enable this in case of slow internet connection, or regualry encountering failed downloads due to network errors.',
+            description: 'Media will be downloaded one after another instead of concurrently. Enable this in case of holding a slow internet connection, or regualry encountering failed downloads due to network errors.',
             input: types.checkbox,
             value: false
         };


### PR DESCRIPTION
Adds a new option to perform sequential downloads instead of concurrent downloads.
This is targeting users reporting problems of failed downloads due to network errors or slow internet connections.

----

<img width="326" alt="Screen Shot 2021-10-23 at 4 36 23 PM" src="https://user-images.githubusercontent.com/27136773/138562188-39a37612-d5bf-4321-a58b-c7004fa0c5d1.png">