### PR TITLE
Fix volume library path, as well as manga with subseries

### DIFF
--- a/src/web/mjs/connectors/VizShonenJump.mjs
+++ b/src/web/mjs/connectors/VizShonenJump.mjs
@@ -140,7 +140,7 @@ export default class VizShonenJump extends Connector {
         if (manga.id.startsWith("/shonenjump/chapters")) {
             return await this._getMangaChapters(manga);
         }
-        if (manga.id.startsWith("/library")) {
+        if (manga.id.startsWith("/account/library")) {
             return await this._getMangaVolumes(manga);
         }
 

--- a/src/web/mjs/connectors/VizShonenJump.mjs
+++ b/src/web/mjs/connectors/VizShonenJump.mjs
@@ -35,7 +35,7 @@ export default class VizShonenJump extends Connector {
     }
 
     async _getMangasAvailibleByVolumes() {
-        const request = new Request(new URL('/library', this.url), this.requestOptions);
+        const request = new Request(new URL('/account/library', this.url), this.requestOptions);
         let data = await this.fetchDOM(request);
 
         if ( data.innerText.includes('Log in to view your library') ) { // User isn't logged in, so there's no availible volumes


### PR DESCRIPTION
The path to a users library is slightly different now, the old path still works for fetching volume based manga on the account, but it cannot be used to get the volumes  within a given manga. This has been addressed.

As well, there are some manga which contain subseries. These manga would otherwise give titles that are simply the `Vol. ${Number}`, despite there being possibly 2 or even far more duplicates of the same volume number given how many sub series they might have. So we try to detect this situation by checking all the volumes start with the same name before the Volume number, and if they don't we assume this manga has subseries and so give each volume the full name to differentiate.