### PR TITLE
mangadex improve getManga

### DIFF
--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -11,7 +11,7 @@ export default class MangaDex extends Connector {
         this.url = 'https://mangadex.org';
         this.api = 'https://api.mangadex.org';
         this.requestOptions.headers.set('x-referer', this.url);
-        this.throttleGlobal = 100;
+        this.throttleGlobal = 200;
         this.licensedChapterGroups = [
             '4f1de6a2-f0c5-4ac5-bce5-02c7dbb67deb', // MangaPlus
             '8d8ecf83-8d42-4f8c-add8-60963f9f28d9' // Comikey
@@ -227,7 +227,7 @@ export default class MangaDex extends Connector {
         retries = retries || 0;
         let response = await fetch( request );
         if( (response.status >= 500 || /captcha-v3$/.test(response.url)) && retries > 0 ) {
-            await this.wait( 500 );
+            await this.wait( 5000 );
             return await this.fetchJSON( request, retries - 1 );
         }
         if( response.status === 200 ) {

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -52,26 +52,26 @@ export default class MangaDex extends Connector {
     }
 
     async _getMangas() {
-        let mangaList = []
-        let data1 = await this._getMangasFromPages(0, 99)
-        mangaList = [...mangaList, ...data1.data]
-        nextAt = data1.nextAt
+        let mangaList = [];
+        let data1 = await this._getMangasFromPages(0, 99);
+        mangaList = [...mangaList, ...data1.data];
+        let nextAt = data1.nextAt;
 
         for (let i = 1; i <= data1.total / 10000; i += 1) {
-            let data2 = await this._getMangasFromPages(1, 1, nextAt)
-            mangaList = [...mangaList, ...data2.data.slice(1)]
-            let pages = Math.min(Math.floor(data2.total / 100), 99)
+            let data2 = await this._getMangasFromPages(1, 1, nextAt);
+            mangaList = [...mangaList, ...data2.data.slice(1)];
+            let pages = Math.min(Math.floor(data2.total / 100), 99);
             if (pages > 0) {
-                let data3 = await this._getMangasFromPages(1, pages, nextAt)
-                mangaList = [...mangaList, ...data3.data]
-                nextAt = data3.nextAt
+                let data3 = await this._getMangasFromPages(1, pages, nextAt);
+                mangaList = [...mangaList, ...data3.data];
+                nextAt = data3.nextAt;
             }
         }
-        return mangaList
+        return mangaList;
     }
 
     async _getMangasFromPages(start, pages, nextAt) {
-        let tmp = []
+        let tmp = [];
         for (let page = start; page <= pages; page += 1) {
             const uri = new URL('/manga', this.api);
             uri.searchParams.set('limit', 100);
@@ -85,15 +85,15 @@ export default class MangaDex extends Connector {
                 return {
                     id: ele.id,
                     title: ele.attributes.title.en || Object.values(ele.attributes.title).shift()
-                }
-            })
-            tmp = [...tmp, ...data3]
+                };
+            });
+            tmp = [...tmp, ...data3];
             if (page == pages) {
                 return {
                     data: tmp,
                     nextAt: data3.data[data3.data.length - 1].attributes.createdAt.match(/^\d{4}-[0-1]\d-([0-2]\d|3[0-1])T([0-1]\d|2[0-3]):[0-5]\d:[0-5]\d/)[0],
                     total: data3.total
-                }
+                };
             }
         }
     }

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -13,7 +13,7 @@ export default class MangaDex extends Connector {
         this.requestOptions.headers.set('x-referer', this.url);
         this.config = {
             throttle: {
-                label: 'Video Stream Throttle [ms]',
+                label: 'Throttle Requests [ms]',
                 description: 'Enter the timespan in [ms] to delay consecuitive requests.',
                 input: 'numeric',
                 min: 100,

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -83,7 +83,7 @@ export default class MangaDex extends Connector {
             uri.searchParams.set('offset', 100 * page);
             uri.searchParams.set('order[createdAt]', 'asc');
             if (nextAt) uri.searchParams.set('createdAtSince', nextAt);
-            const request = new Request(uri);
+            const request = new Request(uri, this.requestOptions);
             let data3 = await this.fetchJSON(request, 3);
             await this.wait(this.throttleGlobal);
             tmp = [...tmp, ...data3.data];

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -11,7 +11,7 @@ export default class MangaDex extends Connector {
         this.url = 'https://mangadex.org';
         this.api = 'https://api.mangadex.org';
         this.requestOptions.headers.set('x-referer', this.url);
-        this.requestOptions.headers.set('x-sec-ch-ua','" Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"')
+        this.requestOptions.headers.set('x-sec-ch-ua', '" Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"');
         this.config = {
             throttle: {
                 label: 'Throttle Requests [ms]',

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -97,7 +97,7 @@ export default class MangaDex extends Connector {
             uri.searchParams.append('contentRating[]', 'pornographic');
             if (nextAt) uri.searchParams.set('createdAtSince', nextAt);
             data100 = await this.fetchJSON(uri, 3);
-            await this.wait(this.config.throttle.value)
+            await this.wait(this.config.throttle.value);
             tmp = [...tmp, ...data100.data];
         }
         return {
@@ -117,7 +117,7 @@ export default class MangaDex extends Connector {
     }
 
     async _getChaptersFromPage(manga, page) {
-        await this.wait(this.config.throttle.value)
+        await this.wait(this.config.throttle.value);
         const uri = new URL('/chapter', this.api);
         uri.searchParams.set('limit', 100);
         uri.searchParams.set('offset', 100 * page);
@@ -199,7 +199,7 @@ export default class MangaDex extends Connector {
         }, []);
         groupIDs = Array.from(new Set(groupIDs));
         if (groupIDs.length > 0) {
-            await this.wait(this.config.throttle.value)
+            await this.wait(this.config.throttle.value);
             const uri = new URL('/group', this.api);
             uri.search = new URLSearchParams([ ['limit', 100 ], ...groupIDs.map(id => [ 'ids[]', id ]) ]).toString();
             const {data} = await this.fetchJSON(uri, 3);

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -13,9 +13,9 @@ export default class MangaDex extends Connector {
         this.requestOptions.headers.set('x-referer', this.url);
         this.requestOptions.headers.set('x-sec-ch-ua', '" Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"');
         this.config = {
-            throttle: {
+            throttleRequests: {
                 label: 'Throttle Requests [ms]',
-                description: 'Enter the timespan in [ms] to delay consecuitive requests.',
+                description: 'Enter the timespan in [ms] to delay consecuitive requests to the api.',
                 input: 'numeric',
                 min: 100,
                 max: 10000,

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -11,6 +11,7 @@ export default class MangaDex extends Connector {
         this.url = 'https://mangadex.org';
         this.api = 'https://api.mangadex.org';
         this.requestOptions.headers.set('x-referer', this.url);
+        this.requestOptions.headers.set('x-sec-ch-ua','" Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"')
         this.config = {
             throttle: {
                 label: 'Throttle Requests [ms]',
@@ -18,7 +19,7 @@ export default class MangaDex extends Connector {
                 input: 'numeric',
                 min: 100,
                 max: 10000,
-                value: 2100
+                value: 200
             }
         };
         this.licensedChapterGroups = [
@@ -229,19 +230,5 @@ export default class MangaDex extends Connector {
             return '0'.repeat(Math.max(0, places - digits)) + chapter;
         });
         return range.join('-');
-    }
-
-    async fetchJSON( uri, retries ) {
-        const request = new Request( uri, this.requestOptions );
-        retries = retries || 0;
-        let response = await fetch( request );
-        if( (response.status >= 500 || /captcha-v3$/.test(response.url)) && retries > 0 ) {
-            await this.wait( 5000 );
-            return await this.fetchJSON( request, retries - 1 );
-        }
-        if( response.status === 200 ) {
-            return response.json();
-        }
-        throw new Error( `Failed to receive content from "${request.url}" (status: ${response.status}) - ${response.statusText}` );
     }
 }

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -131,7 +131,7 @@ export default class MangaDex extends Connector {
         uri.searchParams.set('manga', manga.id);
         const request = new Request(uri, this.requestOptions);
         const {data} = await this.fetchJSON(request, 3);
-         const groupMap = await this._getScanlationGroups(data);
+        const groupMap = await this._getScanlationGroups(data);
         return !data ? [] : data.map(result => {
             let title = '';
             if(result.attributes.volume) {
@@ -203,13 +203,13 @@ export default class MangaDex extends Connector {
             return accumulator.concat(ids);
         }, []);
         groupIDs = Array.from(new Set(groupIDs));
-        if (groupIDs.length > 0) {
+        if(groupIDs.length > 0) {
             await this.wait(this.config.throttle.value);
             const uri = new URL('/group', this.api);
             uri.search = new URLSearchParams([ [ 'limit', 100 ], ...groupIDs.map(id => [ 'ids[]', id ]) ]).toString();
             const request = new Request(uri, this.requestOptions);
             const {data} = await this.fetchJSON(request, 3);
-             data.forEach(result => groupList[result.id] = result.attributes.name || 'unknown');
+            data.forEach(result => groupList[result.id] = result.attributes.name || 'unknown');
         }
         return groupList;
     }

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -58,7 +58,7 @@ export default class MangaDex extends Connector {
         let nextAt = data1.nextAt;
 
         for (let i = 1; i <= data1.total / 10000; i += 1) {
-            let data2 = await this._getMangasFromPages(1, 1, nextAt);
+            let data2 = await this._getMangasFromPages(0, 0, nextAt);
             mangaList = [...mangaList, ...data2.data.slice(1)];
             let pages = Math.min(Math.floor(data2.total / 100), 99);
             if (pages > 0) {

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -87,7 +87,7 @@ export default class MangaDex extends Connector {
             uri.searchParams.append('contentRating[]', 'erotica');
             uri.searchParams.append('contentRating[]', 'pornographic');
             if (nextAt) uri.searchParams.set('createdAtSince', nextAt);
-            data100 = await this.fetchJSON(uri, 3);
+            data100 = await this.fetchJSON(uri, 30);
             await this.wait(this.throttleGlobal);
             tmp = [...tmp, ...data100.data];
         }
@@ -227,7 +227,7 @@ export default class MangaDex extends Connector {
         retries = retries || 0;
         let response = await fetch( request );
         if( (response.status >= 500 || /captcha-v3$/.test(response.url)) && retries > 0 ) {
-            await this.wait( 5000 );
+            await this.wait( 500 );
             return await this.fetchJSON( request, retries - 1 );
         }
         if( response.status === 200 ) {

--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -70,7 +70,7 @@ export default class MangaDex extends Connector {
         return mangaList.map(ele => {
             return {
                 id: ele.id,
-                title: ele.attributes.title.en || Object.values(ele.attributes.title).shift()
+                title: (ele.attributes.title.en || Object.values(ele.attributes.title).shift()).trim()
             };
         });
     }

--- a/src/web/mjs/engine/Request.mjs
+++ b/src/web/mjs/engine/Request.mjs
@@ -491,6 +491,12 @@ export default class Request {
         }
         delete details.requestHeaders['x-sec-fetch-site'];
 
+        //
+        if (details.requestHeaders['x-sec-ch-ua']) {
+            details.requestHeaders['sec-ch-ua'] = details.requestHeaders['x-sec-ch-ua'];
+        }
+        delete details.requestHeaders['x-sec-ch-ua'];
+
         // HACK: Imgur does not support request with accept types containing other mimes then images
         //       => overwrite accept header to prevent redirection to HTML notice
         if (/i\.imgur\.com/i.test(uri.hostname) || /\.(jpg|jpeg|png|gif|webp)/i.test(uri.pathname)) {


### PR DESCRIPTION
this is just #3784 but better

this should be as good as it gets
all manga
minimum requests
(totalManga + floor(totalManga/10000))/100 requests

it would be nice to get rid of the floor(totalManga/10000) (this is currently 5) but dealing with them is easier than possibly missing one by changing the times

it works now fixed the captcha issue (and 503)
resolves #4161