### PR TITLE
Enable security context for hakuneko:// protocol

### DIFF
--- a/src/app/ElectronBootstrap.js
+++ b/src/app/ElectronBootstrap.js
@@ -16,6 +16,7 @@ module.exports = class ElectronBootstrap {
             {
                 scheme: this._configuration.applicationProtocol,
                 privileges: {
+                    secure: true,
                     standard: true,
                     supportFetchAPI: true
                 }


### PR DESCRIPTION
As of now this change only takes affect during development as it would require a rebuild and deployment of HakuNeko desktop clients.