### PR TITLE
Enforce cookies to be supported for cross-site requests

### DIFF
--- a/src/web/mjs/engine/Cookie.mjs
+++ b/src/web/mjs/engine/Cookie.mjs
@@ -37,4 +37,17 @@ export default class Cookie {
         }
         return result;
     }
+
+    static applyCrossSiteCookies(headers) {
+        let cookies = headers['set-cookie'] || headers['Set-Cookie'];
+        if(!cookies) {
+            return;
+        }
+        if(!Array.isArray(cookies)) {
+            cookies = [ cookies ];
+        }
+        for(let index in cookies) {
+            cookies[index] = [ ...cookies[index].split(';').map(part => part.trim()).filter(part => !/^SameSite=/i.test(part)), 'SameSite=None' ].join('; ');
+        }
+    }
 }

--- a/src/web/mjs/engine/Request.mjs
+++ b/src/web/mjs/engine/Request.mjs
@@ -535,6 +535,10 @@ export default class Request {
             delete details.responseHeaders['content-security-policy'];
         }
 
+        if(details.responseHeaders['set-cookie'] || details.responseHeaders['Set-Cookie']) {
+            Cookie.applyCrossSiteCookies(details.responseHeaders);
+        }
+
         return details;
     }
 }


### PR DESCRIPTION
This may solve login problems for some websites.
By default, a cookie is only send with a request when the origin of the website that initiate the request matches the target of the request.

Since the origin of HakuNeko is something like `hakuneko://index.html` a session cookie for a request to `https://some-mangas.net` will not be added.

This fix will adjust cookies, so that they will also be send from an origin (e.g. `hakuneko://index.html`) that does not match the target of the request (e.g. `https://some-mangas.net`).