### PR TITLE
Update MangaDex throttle

### DIFF
--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -19,7 +19,7 @@ export default class MangaDex extends Connector {
                 input: 'numeric',
                 min: 100,
                 max: 10000,
-                value: 200
+                value: 2000
             }
         };
         this.licensedChapterGroups = [


### PR DESCRIPTION
i talked to the mangadex devs and they stated that the errors were intentional (they dont want people to yoink the whole list)
they suggested either running a cron job on a server and get results from that server (similer to how webtoon used to be done)
(i mean a server dumping to pastebin or github would do the same)
or adding proper search functionality to HN itself

a 2 second throttle doesn't have the issue