### PR TITLE
For Previewing Manga: Add Zoom Icons For Full Window Width and Default Zoom Level, and text to show the current image width percentage

### DIFF
--- a/src/web/lib/hakuneko/frontend@classic-dark/pages.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/pages.html
@@ -116,7 +116,11 @@
                     &nbsp;
                     <i class="fas fa-search-plus fa-2x button" title="Zoom In (➕)" on-click="zoomIn"></i>
                     <i class="fas fa-search-minus fa-2x button" title="Zoom Out (➖)" on-click="zoomOut"></i>
-                    &nbsp
+                    &nbsp;
+                    <i class="fas fa-compress-arrows-alt fa-2x button" title="Default Image Width (*)" on-click="defaultZoom"></i>
+                    <i class="fas fa-expand-arrows-alt fa-2x button" title="Zoom to Fit Window (/)" on-click="fullWidthZoom"></i>
+                    &nbsp;
+                    <i>Image Width: [[ imageWidth ]]%</i>
                     <i class="fas fa-times-circle fa-2x button" title="Close (ESC)" on-click="hideViewer"></i>
                 </div>
                 <template is="dom-repeat" items="[[ media ]]" style="margin-top: 1.5em;">
@@ -517,15 +521,29 @@
             /**
              *
              */
+            defaultZoom( event ) {
+                this.set( 'imageWidth', 75);
+            }
+
+            /**
+             *
+             */
+            fullWidthZoom( event ) {
+                 this.set( 'imageWidth', 100);
+            }
+
+            /**
+             *
+             */
             zoom( scale ) {
-                let previousHeight = this.$.container.scrollHeight;
-                let previousOffset = this.$.container.scrollTop;
-                this.set( 'imageWidth', scale );
-                // embed in timeout function to ensure layout is updated before adjusting offsetY
-                //setTimeout( function() {
-                    // adjust new offsetY depending on height changed ratio of container after scaling images
-                    this.$.container.scrollTop = previousOffset * this.$.container.scrollHeight / previousHeight;
-                //}.bind( this ), 0 );
+                    let previousHeight = this.$.container.scrollHeight;
+                    let previousOffset = this.$.container.scrollTop;
+                    this.set( 'imageWidth', scale );
+                    // embed in timeout function to ensure layout is updated before adjusting offsetY
+                    //setTimeout( function() {
+                        // adjust new offsetY depending on height changed ratio of container after scaling images
+                        this.$.container.scrollTop = previousOffset * this.$.container.scrollHeight / previousHeight;
+                    //}.bind( this ), 0 );
             }
 
             /**

--- a/src/web/lib/hakuneko/frontend@classic-dark/pages.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/pages.html
@@ -108,8 +108,8 @@
             <template is="dom-if" if="[[ pageViewMode(media,selectedMedia) ]]">
                 <div id="buttons" tabindex="0" onblur="this.focus()" on-keydown="onKeyDown">
                     <span class="title">[[ selectedChapter.title ]]</span>
-                    <i class="fas fa-chevron-down fa-2x button" title="Chapter Down (ArrowLeft)" on-click="requestChapterDown"></i>
-                    <i class="fas fa-chevron-up fa-2x button" title="Chapter Up (ArrowRight)" on-click="requestChapterUp"></i>
+                    <i class="fas fa-chevron-left fa-2x button" title="Previous Chapter (ArrowLeft)" on-click="requestChapterDown"></i>
+                    <i class="fas fa-chevron-right fa-2x button" title="Next Chapter (ArrowRight)" on-click="requestChapterUp"></i>
                     &nbsp;
                     <i class="fas fa-compress fa-2x button" title="Decrease spacing between images (CTRL ➖)" on-click="decreaseImagePadding"></i>
                     <i class="fas fa-expand fa-2x button" title="Increase spacing between images (CTRL ➕)" on-click="increaseImagePadding"></i>
@@ -121,6 +121,7 @@
                     <i class="fas fa-expand-arrows-alt fa-2x button" title="Zoom to Fit Window (/)" on-click="fullWidthZoom"></i>
                     &nbsp;
                     <i>Image Width: [[ imageWidth ]]%</i>
+                    <i class="fas fa-angle-double-down fa-2x button" title="Magic Scroll Down (SPACEBAR)" on-click="scrollDown"></i>
                     <i class="fas fa-times-circle fa-2x button" title="Close (ESC)" on-click="hideViewer"></i>
                 </div>
                 <template is="dom-repeat" items="[[ media ]]" style="margin-top: 1.5em;">
@@ -536,14 +537,14 @@
              *
              */
             zoom( scale ) {
-                    let previousHeight = this.$.container.scrollHeight;
-                    let previousOffset = this.$.container.scrollTop;
-                    this.set( 'imageWidth', scale );
-                    // embed in timeout function to ensure layout is updated before adjusting offsetY
-                    //setTimeout( function() {
-                        // adjust new offsetY depending on height changed ratio of container after scaling images
-                        this.$.container.scrollTop = previousOffset * this.$.container.scrollHeight / previousHeight;
-                    //}.bind( this ), 0 );
+                let previousHeight = this.$.container.scrollHeight;
+                let previousOffset = this.$.container.scrollTop;
+                this.set( 'imageWidth', scale );
+                // embed in timeout function to ensure layout is updated before adjusting offsetY
+                //setTimeout( function() {
+                    // adjust new offsetY depending on height changed ratio of container after scaling images
+                    this.$.container.scrollTop = previousOffset * this.$.container.scrollHeight / previousHeight;
+                //}.bind( this ), 0 );
             }
 
             /**
@@ -597,6 +598,13 @@
                         behavior: 'smooth' 
                     });
                 }
+            }
+
+            /**
+             *
+             */
+            scrollDown( event ) {
+                this.scrollMagic(window.innerHeight*0.80);
             }
 
         }

--- a/src/web/lib/hakuneko/frontend@classic-light/pages.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/pages.html
@@ -114,9 +114,10 @@
                     <i class="fas fa-compress fa-2x button" title="Decrease spacing between images (CTRL ➖)" on-click="decreaseImagePadding"></i>
                     <i class="fas fa-expand fa-2x button" title="Increase spacing between images (CTRL ➕)" on-click="increaseImagePadding"></i>
                     &nbsp;
-                    <i class="fas fa-search-plus fa-2x button" title="Zoom In (➕)" on-click="zoomIn"></i>
-                    <i class="fas fa-search-minus fa-2x button" title="Zoom Out (➖)" on-click="zoomOut"></i>
-                    &nbsp
+                    <i class="fas fa-compress-arrows-alt fa-2x button" title="Default Image Width (*)" on-click="defaultZoom"></i>
+                    <i class="fas fa-expand-arrows-alt fa-2x button" title="Zoom to Fit Window (/)" on-click="fullWidthZoom"></i>
+                    &nbsp;
+                    <i>Image Width: [[ imageWidth ]]%</i>
                     <i class="fas fa-times-circle fa-2x button" title="Close (ESC)" on-click="hideViewer"></i>
                 </div>
                 <template is="dom-repeat" items="[[ media ]]" style="margin-top: 1.5em;">
@@ -512,6 +513,20 @@
             zoomOut( event ) {
                 let scale = this.imageWidth - 15;
                 this.zoom( ( scale < 25 ? 25 : scale ) );
+            }
+
+            /**
+             *
+             */
+            defaultZoom( event ) {
+                this.set( 'imageWidth', 75);
+            }
+
+            /**
+             *
+             */
+            fullWidthZoom( event ) {
+                this.set( 'imageWidth', 100);
             }
 
             /**

--- a/src/web/lib/hakuneko/frontend@classic-light/pages.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/pages.html
@@ -108,16 +108,20 @@
             <template is="dom-if" if="[[ pageViewMode(media,selectedMedia) ]]">
                 <div id="buttons" tabindex="0" onblur="this.focus()" on-keydown="onKeyDown">
                     <span class="title">[[ selectedChapter.title ]]</span>
-                    <i class="fas fa-chevron-down fa-2x button" title="Chapter Down (ArrowLeft)" on-click="requestChapterDown"></i>
-                    <i class="fas fa-chevron-up fa-2x button" title="Chapter Up (ArrowRight)" on-click="requestChapterUp"></i>
+                    <i class="fas fa-chevron-left fa-2x button" title="Previous Chapter (ArrowLeft)" on-click="requestChapterDown"></i>
+                    <i class="fas fa-chevron-right fa-2x button" title="Next Chapter (ArrowRight)" on-click="requestChapterUp"></i>
                     &nbsp;
                     <i class="fas fa-compress fa-2x button" title="Decrease spacing between images (CTRL ➖)" on-click="decreaseImagePadding"></i>
                     <i class="fas fa-expand fa-2x button" title="Increase spacing between images (CTRL ➕)" on-click="increaseImagePadding"></i>
+                    &nbsp;
+                    <i class="fas fa-search-plus fa-2x button" title="Zoom In (➕)" on-click="zoomIn"></i>
+                    <i class="fas fa-search-minus fa-2x button" title="Zoom Out (➖)" on-click="zoomOut"></i>
                     &nbsp;
                     <i class="fas fa-compress-arrows-alt fa-2x button" title="Default Image Width (*)" on-click="defaultZoom"></i>
                     <i class="fas fa-expand-arrows-alt fa-2x button" title="Zoom to Fit Window (/)" on-click="fullWidthZoom"></i>
                     &nbsp;
                     <i>Image Width: [[ imageWidth ]]%</i>
+                    <i class="fas fa-angle-double-down fa-2x button" title="Magic Scroll Down (SPACEBAR)" on-click="scrollDown"></i>
                     <i class="fas fa-times-circle fa-2x button" title="Close (ESC)" on-click="hideViewer"></i>
                 </div>
                 <template is="dom-repeat" items="[[ media ]]" style="margin-top: 1.5em;">
@@ -594,6 +598,13 @@
                         behavior: 'smooth' 
                     });
                 }
+            }
+
+            /**
+             *
+             */
+             scrollDown( event ) {
+                this.scrollMagic(window.innerHeight*0.80);
             }
 
         }


### PR DESCRIPTION
For the previewing manga window, when a manga image is clicked on:

Added Zoom Icons For Full Window Width and Default Zoom Level.
The functionality for these were already available by pressing * or / on the keyboard but there were no icons for these in the top menu bar.
The user can now either click the icon or press the appropriate button.
Tooltips with the keyboard shortcuts have also been added for both, tooltips appear by hovering over the icons.

Text to show the current image width for the window has also been added.

This has been added for both the light and dark theme.

The new icons and text are in the red rectangle: https://i.imgur.com/nhrWrS0.png