### PR TITLE
Better identify the languages in Manga Plus.

### DIFF
--- a/src/web/mjs/connectors/ShueishaMangaPlus.mjs
+++ b/src/web/mjs/connectors/ShueishaMangaPlus.mjs
@@ -15,22 +15,10 @@ export default class ShueishaMangaPlus extends Publus {
     }
 
     _getLanguage(language) {
-        switch (language) {
-            case 1:
-                return ' [es]';
-            case 2:
-                return ' [fr]';
-            case 3:
-                return ' [id]';
-            case 4:
-                return ' [pt-br]';
-            case 5:
-                return ' [ru]';
-            case 6:
-                return ' [th]';
-            default:
-                return ' [en]';
-        }
+        const languages = {
+            1: '[es]', 2: '[fr]', 3: '[id]', 4: '[pt-br]', 5: '[ru]', 6: '[th]'
+        };
+        return languages[language] || '[en]';
     }
 
     async _getMangaFromURI(uri) {
@@ -40,7 +28,7 @@ export default class ShueishaMangaPlus extends Publus {
         let request = new Request(uri, this.requestOptions);
         let data = await this.fetchPROTO(request, this.protoTypes, this.rootType);
         let title = data.success.titleDetailView.title;
-        title = title.name + this._getLanguage(title.language);
+        title = `${title.name} ${this._getLanguage(title.language)}`;
         return new Manga(this, id, title);
     }
 
@@ -50,7 +38,7 @@ export default class ShueishaMangaPlus extends Publus {
         return data.success.allTitlesView.titles.map(manga => {
             return {
                 id: manga.titleId,
-                title: manga.name + this._getLanguage(manga.language)
+                title: `${manga.name} ${this._getLanguage(manga.language)}`
             };
         });
     }

--- a/src/web/mjs/connectors/ShueishaMangaPlus.mjs
+++ b/src/web/mjs/connectors/ShueishaMangaPlus.mjs
@@ -14,6 +14,25 @@ export default class ShueishaMangaPlus extends Publus {
         this.rootType = 'MangaPlus.Response';
     }
 
+    _getLanguage(language) {
+        switch (language) {
+            case 1:
+                return ' [es]';
+            case 2:
+                return ' [fr]';
+            case 3:
+                return ' [id]';
+            case 4:
+                return ' [pt-br]';
+            case 5:
+                return ' [ru]';
+            case 6:
+                return ' [th]';
+            default:
+                return ' [en]';
+        }
+    }
+
     async _getMangaFromURI(uri) {
         let id = uri.pathname.match(/\/(\d+)$/)[1];
         uri = new URL('/api/title_detail', this.apiURL);
@@ -21,7 +40,7 @@ export default class ShueishaMangaPlus extends Publus {
         let request = new Request(uri, this.requestOptions);
         let data = await this.fetchPROTO(request, this.protoTypes, this.rootType);
         let title = data.success.titleDetailView.title;
-        title = title.name + (title.language ? ' [es]' : ' [en]');
+        title = title.name + this._getLanguage(title.language);
         return new Manga(this, id, title);
     }
 
@@ -31,7 +50,7 @@ export default class ShueishaMangaPlus extends Publus {
         return data.success.allTitlesView.titles.map(manga => {
             return {
                 id: manga.titleId,
-                title: manga.name + (manga.language ? ' [es]' : ' [en]')
+                title: manga.name + this._getLanguage(manga.language)
             };
         });
     }


### PR DESCRIPTION
Fix the language identifier because now, MangaPlus publish mangas in several languages, instead of English and Spanish only.

Before
![image](https://user-images.githubusercontent.com/5881027/151672068-529fe8de-12e6-4fe8-a730-43981c317859.png)


After
![image](https://user-images.githubusercontent.com/5881027/151671948-fc1a37b9-2c92-493f-9f41-16e8bbc391d4.png)
