### PR TITLE
fix naver new links now showing up

### DIFF
--- a/src/web/mjs/connectors/Naver.mjs
+++ b/src/web/mjs/connectors/Naver.mjs
@@ -19,7 +19,7 @@ export default class Naver extends Connector {
         let data = await this.fetchDOM(request, 'div#content div.comicinfo div.detail h2 span.title', 3);
         uri.searchParams.delete('page');
         let id = uri.pathname + uri.search;
-        let title = data[0].childNodes[0].nodeValue.trim();
+        let title = data[0].textContent.trim();
         return new Manga(this, id, title);
     }
 


### PR DESCRIPTION
if you tried to load a new url(not from bookmarks) in naver it said it found a title but didn't show as the title was empty. Now fixed