### PR TITLE
Fixed #4402

### DIFF
--- a/src/web/mjs/connectors/EHentai.mjs
+++ b/src/web/mjs/connectors/EHentai.mjs
@@ -59,9 +59,7 @@ export default class EHentai extends Connector {
 
     async _handleConnectorURI(payload) {
         let request = new Request(payload, this.requestOptions);
-        let dataFull = await this.fetchDOM(request, 'a[href*="fullimg.php"]');
-        let dataImg = await this.fetchDOM(request, 'source#img');
-        let data = [...dataFull, ...dataImg];
+        let data = await this.fetchDOM(request, 'source#img, a[href*="fullimg.php"]').reverse();
         let response = await fetch(this.getAbsolutePath(data[0], request.url), this.requestOptions);
         if(!response.headers.get('content-type').startsWith('image/')) {
             response = await fetch(this.getAbsolutePath(data[0], request.url), this.requestOptions);

--- a/src/web/mjs/connectors/EHentai.mjs
+++ b/src/web/mjs/connectors/EHentai.mjs
@@ -59,7 +59,9 @@ export default class EHentai extends Connector {
 
     async _handleConnectorURI(payload) {
         let request = new Request(payload, this.requestOptions);
-        let data = await this.fetchDOM(request, 'source#img, a[href*="fullimg.php"]');
+        let dataFull = await this.fetchDOM(request, 'a[href*="fullimg.php"]');
+        let dataImg = await this.fetchDOM(request, 'source#img');
+        let data = [...dataFull, ...dataImg];
         let response = await fetch(this.getAbsolutePath(data[0], request.url), this.requestOptions);
         if(!response.headers.get('content-type').startsWith('image/')) {
             response = await fetch(this.getAbsolutePath(data[0], request.url), this.requestOptions);

--- a/src/web/mjs/connectors/EHentai.mjs
+++ b/src/web/mjs/connectors/EHentai.mjs
@@ -59,7 +59,7 @@ export default class EHentai extends Connector {
 
     async _handleConnectorURI(payload) {
         let request = new Request(payload, this.requestOptions);
-        let data = await this.fetchDOM(request, 'source#img, a[href*="fullimg.php"]').reverse();
+        let data = (await this.fetchDOM(request, 'source#img, a[href*="fullimg.php"]')).reverse()
         let response = await fetch(this.getAbsolutePath(data[0], request.url), this.requestOptions);
         if(!response.headers.get('content-type').startsWith('image/')) {
             response = await fetch(this.getAbsolutePath(data[0], request.url), this.requestOptions);

--- a/src/web/mjs/connectors/EHentai.mjs
+++ b/src/web/mjs/connectors/EHentai.mjs
@@ -59,7 +59,7 @@ export default class EHentai extends Connector {
 
     async _handleConnectorURI(payload) {
         let request = new Request(payload, this.requestOptions);
-        let data = (await this.fetchDOM(request, 'source#img, a[href*="fullimg.php"]')).reverse()
+        let data = (await this.fetchDOM(request, 'source#img, a[href*="fullimg.php"]')).reverse();
         let response = await fetch(this.getAbsolutePath(data[0], request.url), this.requestOptions);
         if(!response.headers.get('content-type').startsWith('image/')) {
             response = await fetch(this.getAbsolutePath(data[0], request.url), this.requestOptions);


### PR DESCRIPTION
So, here's what was the problem.
`let data = await this.fetchDOM(request, 'source#img, a[href*="fullimg.php"]');`
`fetchDOM` then does `querySelectorAll` 
Then we take `data[0]`
The problem is `querySelectorAll` returns NodeList not in order we call them, but in order it first appears in DOM itself, which means `data[0]` will ALWAYS be low res `source#img`
AFAIK the only fix is either two calls or sorting them afterwards.

Tested, works fine.

https://github.com/manga-download/hakuneko/issues/4402