### PR TITLE
Jiangzaitoon - Domain Change

### DIFF
--- a/src/web/mjs/connectors/JiangzaiToon.mjs
+++ b/src/web/mjs/connectors/JiangzaiToon.mjs
@@ -7,6 +7,6 @@ export default class JiangzaiToon extends WordPressMadara {
         super.id = 'jiangzaitoon';
         super.label = 'Jiangzaitoon';
         this.tags = [ 'webtoon', 'hentai', 'turkish' ];
-        this.url = 'https://jiangzaitoon.net';
+        this.url = 'https://jiangzaitoon.org';
     }
 }


### PR DESCRIPTION
Changed the domain from "https://jiangzaitoon.net" to "https://jiangzaitoon.org"