### PR TITLE
Fix user-agent value for CoreView connector

### DIFF
--- a/src/web/mjs/connectors/templates/CoreView.mjs
+++ b/src/web/mjs/connectors/templates/CoreView.mjs
@@ -9,9 +9,9 @@ export default class CoreView extends Connector {
         super.label = undefined;
         this.tags = [];
         this.url = undefined;
-        this.requestOptions.headers.set('x-user-agent', 'Mozilla/5.0 (iPod; CPU iPhone OS 14_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/87.0.4280.163 Mobile/15E148 Safari/604.1');
+        this.requestOptions.headers.set('x-user-agent', 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.80 Safari/537.36');
         // The URL pathes to parse
-        this.path = [ '/series', '/series/oneshot', '/series/finished' ];
+        this.path = ['/series', '/series/oneshot', '/series/finished'];
         // The query to select *all* required data for *one* manga
         this.queryManga = 'article.series-list-wrapper ul.series-list > li.series-list-item > a';
         // Optional query to pinpoint the URI inside of this.queryManga . Most sites don't need this
@@ -38,7 +38,7 @@ export default class CoreView extends Connector {
 
     async _getMangas() {
         let mangaList = [];
-        for(let page of this.path) {
+        for (let page of this.path) {
             let mangas = await this._getMangasFromPage(page);
             mangaList.push(...mangas);
         }
@@ -66,7 +66,7 @@ export default class CoreView extends Connector {
             content = content.replace(/<img/g, '<source');
             content = content.replace(/<\/img/g, '</source');
             element.innerHTML = content;
-        } catch(_) {
+        } catch (_) {
             return Promise.resolve();
         }
     }
@@ -90,12 +90,12 @@ export default class CoreView extends Connector {
         let request = new Request(new URL(chapter.id, this.url), this.requestOptions);
         let dataElement = await this.fetchDOM(request, this.queryEpisodeJSON);
         let data = JSON.parse(dataElement[0].dataset.value);
-        if(!data.readableProduct.isPublic && !data.readableProduct.hasPurchased) {
+        if (!data.readableProduct.isPublic && !data.readableProduct.hasPurchased) {
             throw new Error(`The chapter '${chapter.title}' is neither public, nor purchased!`);
         }
         return data.readableProduct.pageStructure.pages.filter(page => page.type === 'main').map(page => {
             // NOTE: 'usagi' is not scrambled
-            if(data.readableProduct.pageStructure.choJuGiga === 'baku') {
+            if (data.readableProduct.pageStructure.choJuGiga === 'baku') {
                 return this.createConnectorURI(page.src);
             } else {
                 return this.getAbsolutePath(page.src, request.url);
@@ -146,7 +146,7 @@ export default class CoreView extends Connector {
 
             canvas.toBlob(data => {
                 resolve(data);
-            }, Engine.Settings.recompressionFormat.value, parseFloat( Engine.Settings.recompressionQuality.value )/100);
+            }, Engine.Settings.recompressionFormat.value, parseFloat(Engine.Settings.recompressionQuality.value) / 100);
         });
     }
 


### PR DESCRIPTION
There is weird problem that current CoreView connect cannot load chapters properly for recently updated manga.
I investigated the reason and found that user-agent value of request headers was problem.
Checked with MagComi(https://magcomi.com/), especially this manga (https://magcomi.com/episode/3269754496670883221)

Request with previous user-agent value
![img003](https://user-images.githubusercontent.com/1590516/156875483-122cdc6b-4d31-4758-a871-f5d28c6349b7.png)
![img004](https://user-images.githubusercontent.com/1590516/156875484-664a30ee-fe23-4eba-b662-53441b457c40.png)
Response has only two entries.

Request with new user-agent value (Windows Chrome's user-agent value)
![img001](https://user-images.githubusercontent.com/1590516/156875513-2727d1ea-5191-42aa-bead-3918b7648620.png)
![img002](https://user-images.githubusercontent.com/1590516/156875516-79ac81bb-bafa-48a7-ba48-b9d04b3a3141.png)
This has 3 entries normally.
