### PR TITLE
Allow Manhuagui To Accept Abbreviated Domain

### DIFF
--- a/src/web/mjs/connectors/ManHuaGui.mjs
+++ b/src/web/mjs/connectors/ManHuaGui.mjs
@@ -39,6 +39,10 @@ export default class ManHuaGui extends SinMH {
         `;
     }
 
+    canHandleURI(uri) {
+        return /https?:\/\/(?:www\.)?(mhgui|manhuagui).com/.test(uri.origin);
+    }
+
     async _getMangas() {
         let msg = 'This function was disabled to prevent of being IP banned by the website owner, please copy and paste the URL containing the chapters directly from your browser into HakuNeko.';
         throw new Error(msg);


### PR DESCRIPTION
# Issue

The Manhuagui connector does not allow users to connect via the GUI and requests that users paste in the url. However, the manhuagui domain appears to rotate between domains and the abbreviated domain is not accepted.

# Error Message

After inputting, mhgui.com/comic/3405 , the application returned this warning to the dev console:

`https://www.mhgui.com/comic/3405/ Error: No matching connector found for URL https://www.mhgui.com/comic/3405/`

# Solution

As suggested and usages already exist with other connectors, a canHandleURI method was added that will test for both the full domain, as well as the abbreviation.