### PR TITLE
[Mangadex] reverse order to keep consistent

### DIFF
--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -125,7 +125,7 @@ export default class MangaDex extends Connector {
             let chapters = await this._getChaptersFromPage(manga, page);
             chapters.length > 0 ? chapterList.push(...chapters) : run = false;
         }
-        return chapterList;
+        return chapterList.reverse();
     }
 
     async _getChaptersFromPage(manga, page) {


### PR DESCRIPTION
only mangadex listed latest chapters on bottom line.
this fix it. (#2279)