### PR TITLE
Removed Login need from CrunchyManga Clipboard processor

### DIFF
--- a/src/web/mjs/connectors/CrunchyManga.mjs
+++ b/src/web/mjs/connectors/CrunchyManga.mjs
@@ -97,7 +97,6 @@ export default class CrunchyManga extends Crunchyroll {
     }
 
     async _getMangaFromURI(uri) {
-        await this._login();
         const request = new Request(uri, this.requestOptions);
         let response = await this.fetchDOM(request);
         let title = response.querySelector('title').innerText.trim().replace('Crunchyroll - ', '');


### PR DESCRIPTION
Can create login issues. Got Blocked many times with login. as this is not needed and fetcher still works fine, hence removed