### PR TITLE
Manhwa18com connector

### DIFF
--- a/src/web/mjs/connectors/Manhwa18.mjs
+++ b/src/web/mjs/connectors/Manhwa18.mjs
@@ -1,5 +1,4 @@
 import Connector from '../engine/Connector.mjs';
-import Manga from '../engine/Manga.mjs';
 
 export default class Manhwa18 extends Connector {
 
@@ -44,7 +43,6 @@ export default class Manhwa18 extends Connector {
     }
 
     async _getPages(chapter) {
-        // let request = new Request(this.url + chapter.id, this.requestOptions); //works here
         let request = new Request(this.url + chapter.id, this.requestOptions); 
         let data = await this.fetchDOM(request, 'div#chapter-content source.lazy');
         return data.map(element => this.getAbsolutePath(element.dataset.src || element, request.url));

--- a/src/web/mjs/connectors/Manhwa18.mjs
+++ b/src/web/mjs/connectors/Manhwa18.mjs
@@ -18,9 +18,9 @@ export default class Manhwa18 extends Connector {
         }
         return mangaList;
     }
-    
+
     async _getMangasFromPage(page) {
-        let request = new Request(this.url + '/manga-list?page=' + page ,this.requestOptions);
+        let request = new Request(this.url + '/manga-list?page=' + page, this.requestOptions);
         let data = await this.fetchDOM(request, 'div.series-title a');
         return data.map(element => {
             return {
@@ -31,7 +31,7 @@ export default class Manhwa18 extends Connector {
     }
 
     async _getChapters(manga) {
-        let request = new Request(this.url + manga.id, this.requestOptions); 
+        let request = new Request(this.url + manga.id, this.requestOptions);
         let data = await this.fetchDOM(request, 'ul.list-chapters a');
         return data.map(element => {
             return {
@@ -43,7 +43,7 @@ export default class Manhwa18 extends Connector {
     }
 
     async _getPages(chapter) {
-        let request = new Request(this.url + chapter.id, this.requestOptions); 
+        let request = new Request(this.url + chapter.id, this.requestOptions);
         let data = await this.fetchDOM(request, 'div#chapter-content source.lazy');
         return data.map(element => this.getAbsolutePath(element.dataset.src || element, request.url));
     }

--- a/src/web/mjs/connectors/Manhwa18.mjs
+++ b/src/web/mjs/connectors/Manhwa18.mjs
@@ -1,6 +1,7 @@
-import FlatManga from './templates/FlatManga.mjs';
+import Connector from '../engine/Connector.mjs';
+import Manga from '../engine/Manga.mjs';
 
-export default class Manhwa18 extends FlatManga {
+export default class Manhwa18 extends Connector {
 
     constructor() {
         super();
@@ -8,8 +9,44 @@ export default class Manhwa18 extends FlatManga {
         super.label = 'Manhwa 18 (.com)';
         this.tags = [ 'hentai', 'multi-lingual' ];
         this.url = 'https://manhwa18.com';
-        this.requestOptions.headers.set('x-referer', this.url);
+    }
 
-        this.language = 'en';
+    async _getMangas() {
+        let mangaList = [];
+        for (let page = 1, run = true; run; page++) {
+            const mangas = await this._getMangasFromPage(page);
+            mangas.length > 0 ? mangaList.push(...mangas) : run = false;
+        }
+        return mangaList;
+    }
+    
+    async _getMangasFromPage(page) {
+        let request = new Request(this.url + '/manga-list?page=' + page ,this.requestOptions);
+        let data = await this.fetchDOM(request, 'div.series-title a');
+        return data.map(element => {
+            return {
+                id: this.getRootRelativeOrAbsoluteLink(element, request.url),
+                title: element.text.trim()
+            };
+        });
+    }
+
+    async _getChapters(manga) {
+        let request = new Request(this.url + manga.id, this.requestOptions); 
+        let data = await this.fetchDOM(request, 'ul.list-chapters a');
+        return data.map(element => {
+            return {
+                id: this.getRootRelativeOrAbsoluteLink(element, request.url),
+                title: element.text.trim(),
+                language: ''
+            };
+        });
+    }
+
+    async _getPages(chapter) {
+        // let request = new Request(this.url + chapter.id, this.requestOptions); //works here
+        let request = new Request(this.url + chapter.id, this.requestOptions); 
+        let data = await this.fetchDOM(request, 'div#chapter-content source.lazy');
+        return data.map(element => this.getAbsolutePath(element.dataset.src || element, request.url));
     }
 }


### PR DESCRIPTION
Website: Manhwa18.com 
Issue: had an update that broke the connector

Resolves the following open issues:
https://github.com/manga-download/hakuneko/issues/4483
https://github.com/manga-download/hakuneko/issues/4320
https://github.com/manga-download/hakuneko/issues/4279
https://github.com/manga-download/hakuneko/issues/4151

Before:
Even after synch, manga list is empty.
![image](https://user-images.githubusercontent.com/9809253/178092710-b7b6d011-e0f1-4024-bfee-405712016092.png)

After:
Everything working as expected.
![image](https://user-images.githubusercontent.com/9809253/178092683-2836ce18-26f0-4526-b27a-40b1b2f60e80.png)
