### PR TITLE
Manhwa18net connector

### DIFF
--- a/src/web/mjs/connectors/ManhwaEighteen.mjs
+++ b/src/web/mjs/connectors/ManhwaEighteen.mjs
@@ -45,7 +45,7 @@ export default class ManhwaEighteen extends Connector {
         return data.map(element => {
             return {
                 id: this.getRootRelativeOrAbsoluteLink(element, request.url),
-                title: element.text.trim(),
+                title: element.querySelector('div.chapter-name').textContent.trim(),
                 language: ''
             };
         });

--- a/src/web/mjs/connectors/ManhwaEighteen.mjs
+++ b/src/web/mjs/connectors/ManhwaEighteen.mjs
@@ -1,4 +1,5 @@
 import Connector from '../engine/Connector.mjs';
+import Manga from '../engine/Manga.mjs';
 
 export default class ManhwaEighteen extends Connector {
 
@@ -51,5 +52,13 @@ export default class ManhwaEighteen extends Connector {
         let request = new Request(this.url + chapter.id, this.requestOptions);
         let data = await this.fetchDOM(request, 'div.chapter-content source._lazy');
         return data.map(element => this.getAbsolutePath(element.dataset.src || element, request.url));
+    }
+
+    async _getMangaFromURI(uri) {
+        let request = new Request(uri, this.requestOptions);
+        let data = await this.fetchDOM(request, 'nav ol li.active');
+        let id = uri.pathname;
+        let title = (data[0].content || data[0].textContent).trim();
+        return new Manga(this, id, title);
     }
 }

--- a/src/web/mjs/connectors/ManhwaEighteen.mjs
+++ b/src/web/mjs/connectors/ManhwaEighteen.mjs
@@ -1,6 +1,6 @@
-import FlatManga from './templates/FlatManga.mjs';
+import Connector from '../engine/Connector.mjs';
 
-export default class ManhwaEighteen extends FlatManga {
+export default class ManhwaEighteen extends Connector {
 
     constructor() {
         super();

--- a/src/web/mjs/connectors/ManhwaEighteen.mjs
+++ b/src/web/mjs/connectors/ManhwaEighteen.mjs
@@ -8,10 +8,6 @@ export default class ManhwaEighteen extends FlatManga {
         super.label = 'Manhwa 18 (.net)';
         this.tags = [ 'hentai', 'multi-lingual' ];
         this.url = 'https://manhwa18.net';
-        this.requestOptions.headers.set('x-referer', this.url);
-        this.requestOptions.headers.set('x-cookies', "cf_use_ob=0");
-        this.requestOptions.headers.set('x-cookies', "cf_ob_info=520:727ecb266cde4745:SIN");
-        // this.requestOptions.headers.set('x-cookies', "PHPSESSID=bnltt6cutg4g0d9moic50li5aj");
     }
 
     async _getMangas() {
@@ -35,6 +31,7 @@ export default class ManhwaEighteen extends FlatManga {
     }
 
     async _getChapters(manga) {
+
         let request = new Request(this.url + manga.id, this.requestOptions);
         let data = await this.fetchDOM(request, 'ul.list-chapters a');
         return data.map(element => {

--- a/src/web/mjs/connectors/ManhwaEighteen.mjs
+++ b/src/web/mjs/connectors/ManhwaEighteen.mjs
@@ -14,7 +14,15 @@ export default class ManhwaEighteen extends FlatManga {
         let mangaList = [];
         for (let page = 1, run = true; run; page++) {
             const mangas = await this._getMangasFromPage(page);
-            mangas.length > 0 ? mangaList.push(...mangas) : run = false;
+            if (JSON.stringify(mangaList[mangaList.length - 1]) == undefined && mangas[mangas.length - 1] != undefined ) {
+                mangaList.push(...mangas);
+            } else if (JSON.stringify(mangaList[mangaList.length - 1].id) != JSON.stringify(mangas[mangas.length - 1].id)) {
+                if (mangas.length > 0) {
+                    mangaList.push(...mangas);
+                }
+            } else {
+                run = false;
+            }
         }
         return mangaList;
     }

--- a/src/web/mjs/connectors/ManhwaEighteen.mjs
+++ b/src/web/mjs/connectors/ManhwaEighteen.mjs
@@ -12,17 +12,13 @@ export default class ManhwaEighteen extends Connector {
 
     async _getMangas() {
         let mangaList = [];
-        for (let page = 1, run = true; run; page++) {
+        const uri = new URL('/manga-list.html?listType=pagination&sort=name&sort_type=ASC', this.url);
+        const request = new Request(uri, this.requestOptions);
+        const data = await this.fetchDOM(request, 'div.pagination-wrap ul.pagination li:nth-last-child(2) a');
+        const pageCount = parseInt(data[0].text.trim());
+        for (let page = 1; page <= pageCount; page++) {
             const mangas = await this._getMangasFromPage(page);
-            if (JSON.stringify(mangaList[mangaList.length - 1]) == undefined && mangas[mangas.length - 1] != undefined ) {
-                mangaList.push(...mangas);
-            } else if (JSON.stringify(mangaList[mangaList.length - 1].id) != JSON.stringify(mangas[mangas.length - 1].id)) {
-                if (mangas.length > 0) {
-                    mangaList.push(...mangas);
-                }
-            } else {
-                run = false;
-            }
+            mangaList.push(...mangas);
         }
         return mangaList;
     }

--- a/src/web/mjs/connectors/ManhwaEighteen.mjs
+++ b/src/web/mjs/connectors/ManhwaEighteen.mjs
@@ -9,7 +9,46 @@ export default class ManhwaEighteen extends FlatManga {
         this.tags = [ 'hentai', 'multi-lingual' ];
         this.url = 'https://manhwa18.net';
         this.requestOptions.headers.set('x-referer', this.url);
+        this.requestOptions.headers.set('x-cookies', "cf_use_ob=0");
+        this.requestOptions.headers.set('x-cookies', "cf_ob_info=520:727ecb266cde4745:SIN");
+        // this.requestOptions.headers.set('x-cookies', "PHPSESSID=bnltt6cutg4g0d9moic50li5aj");
+    }
 
-        this.language = '';
+    async _getMangas() {
+        let mangaList = [];
+        for (let page = 1, run = true; run; page++) {
+            const mangas = await this._getMangasFromPage(page);
+            mangas.length > 0 ? mangaList.push(...mangas) : run = false;
+        }
+        return mangaList;
+    }
+
+    async _getMangasFromPage(page) {
+        let request = new Request(this.url + '/manga-list.html?listType=pagination&sort=name&sort_type=ASC&page=' + page, this.requestOptions);
+        let data = await this.fetchDOM(request, 'div.series-title a');
+        return data.map(element => {
+            return {
+                id: this.getRootRelativeOrAbsoluteLink(element, request.url),
+                title: element.text.trim()
+            };
+        });
+    }
+
+    async _getChapters(manga) {
+        let request = new Request(this.url + manga.id, this.requestOptions);
+        let data = await this.fetchDOM(request, 'ul.list-chapters a');
+        return data.map(element => {
+            return {
+                id: this.getRootRelativeOrAbsoluteLink(element, request.url),
+                title: element.text.trim(),
+                language: ''
+            };
+        });
+    }
+
+    async _getPages(chapter) {
+        let request = new Request(this.url + chapter.id, this.requestOptions);
+        let data = await this.fetchDOM(request, 'div.chapter-content source._lazy');
+        return data.map(element => this.getAbsolutePath(element.dataset.src || element, request.url));
     }
 }


### PR DESCRIPTION
https://github.com/manga-download/hakuneko/issues/4816

Solves issue for Manhwa18.net connector not working due to website update.

Be advised that there are pages / manhwa that they are hosting that seems to be broken even during normal browsing. I thought this was due to a header issue prior, but its not. Their site is just broken.
Before:
![image](https://user-images.githubusercontent.com/9809253/178109122-d6ad25c4-7f61-470c-83f0-d62333da4ba5.png)
After:
![image](https://user-images.githubusercontent.com/9809253/178102554-55f9a980-d69d-4258-b71d-97ea9360cfd8.png)
