### PR TITLE
[Mangapark] Fix getting manga title from clipboard

### DIFF
--- a/src/web/mjs/connectors/MangaParkEN.mjs
+++ b/src/web/mjs/connectors/MangaParkEN.mjs
@@ -35,13 +35,12 @@ export default class MangaParkEN extends Connector {
     async _getMangasFromPage(page) {
         const uri = new URL('/browse?sort=name&page=' + page, this.url);
         const request = new Request(uri, this.requestOptions);
-        const data = await this.fetchDOM(request, '#subject-list div.item');
+        const data = await this.fetchDOM(request, '#subject-list div.item a.fw-bold');
         return data.map( element => {
-            const a = element.querySelector('a.fw-bold');
-            this.cfMailDecrypt(a);
+            this.cfMailDecrypt(element);
             return {
-                id: this.getRootRelativeOrAbsoluteLink(a, request.url).match(/\/(\d+)\/?/)[1],
-                title: a.text.trim()
+                id: this.getRootRelativeOrAbsoluteLink(element, request.url).match(/\/(\d+)\/?/)[1],
+                title: element.text.trim()
             };
         });
     }

--- a/src/web/mjs/connectors/MangaParkEN.mjs
+++ b/src/web/mjs/connectors/MangaParkEN.mjs
@@ -15,8 +15,11 @@ export default class MangaParkEN extends Connector {
 
     async _getMangaFromURI(uri) {
         const request = new Request(uri, this.requestOptions);
-        const data = await this.fetchDOM(request, 'main h3');
-        return new Manga(this, uri.pathname.match(/\/(\d+)\/?/)[1], data[0].textContent.trim());
+        let queryMangaTitleFromURI = 'meta[property="og:title"]';
+        if (/\/title\/\d+/.test(uri.pathname))
+            queryMangaTitleFromURI = 'main h3';
+        const data = await this.fetchDOM(request, queryMangaTitleFromURI);
+        return new Manga(this, uri.pathname.match(/\/(\d+)\/?/)[1], (data[0].textContent || data[0].content).trim());
     }
 
     async _getMangas() {

--- a/src/web/mjs/connectors/MangaParkEN.mjs
+++ b/src/web/mjs/connectors/MangaParkEN.mjs
@@ -15,8 +15,8 @@ export default class MangaParkEN extends Connector {
 
     async _getMangaFromURI(uri) {
         const request = new Request(uri, this.requestOptions);
-        const data = await this.fetchDOM(request, 'meta[property="og:title"]');
-        return new Manga(this, uri.pathname.match(/\/(\d+)\/?/)[1], data[0].content.trim());
+        const data = await this.fetchDOM(request, 'main h3');
+        return new Manga(this, uri.pathname.match(/\/(\d+)\/?/)[1], data[0].textContent.trim());
     }
 
     async _getMangas() {

--- a/src/web/mjs/connectors/MangaParkEN.mjs
+++ b/src/web/mjs/connectors/MangaParkEN.mjs
@@ -15,10 +15,8 @@ export default class MangaParkEN extends Connector {
 
     async _getMangaFromURI(uri) {
         const request = new Request(uri, this.requestOptions);
-        let queryMangaTitleFromURI = 'meta[property="og:title"]';
-        if (/\/title\/\d+/.test(uri.pathname))
-            queryMangaTitleFromURI = 'main h3';
-        const data = await this.fetchDOM(request, queryMangaTitleFromURI);
+        const queryMangaTitle = /\/title\/\d+/.test(uri.pathname) ? 'main h3' : 'meta[property="og:title"]';
+        const data = await this.fetchDOM(request, queryMangaTitle);
         return new Manga(this, uri.pathname.match(/\/(\d+)\/?/)[1], (data[0].textContent || data[0].content).trim());
     }
 


### PR DESCRIPTION
Mangapark added endpoints with new front-end - `React`, so query selector has to be different for old and new front-end.