### PR TITLE
[VizShonenJump] update SJ membership check

### DIFF
--- a/src/web/mjs/connectors/VizShonenJump.mjs
+++ b/src/web/mjs/connectors/VizShonenJump.mjs
@@ -30,7 +30,7 @@ export default class VizShonenJump extends Connector {
         return {
             isLoggedIn: /user_id\s*=\s*[1-9]\d*/.test(data),
             isAdult: /adult\s*=\s*true/.test(data),
-            isMember: /is_wsj_subscriber\s*=\s*true/.test(data)
+            isMember: /is_sj_subscriber\s*=\s*true/.test(data)
         };
     }
 


### PR DESCRIPTION
Fixes #5139.

`_getUserInfo()` uses regex to check the response text of <https://viz.com/account/refresh_login_links> to determine if the user has a Shonen Jump membership - if they do, then `_getMangaChapters()` will display the premium chapters. The Viz backend changed and renamed the variable to `is_sj_subsciber`. This can be verified by going to the link and checking the raw response text at line 37.

This fix works, at least on my machine - when logged out, it only displays free chapters; when logged in to an account with a SJ membership, it displays the premium chapters and I'm able to access them.