### PR TITLE
Mangahub.io : Remove API Key stuff

### DIFF
--- a/src/web/mjs/connectors/MangaHub.mjs
+++ b/src/web/mjs/connectors/MangaHub.mjs
@@ -1,6 +1,4 @@
 import Connector from '../engine/Connector.mjs';
-//import Cookie from '../engine/Cookie.mjs';
-//import HeaderGenerator from '../engine/HeaderGenerator.mjs';
 import Manga from '../engine/Manga.mjs';
 
 export default class MangaHub extends Connector {
@@ -34,7 +32,6 @@ export default class MangaHub extends Connector {
                 if (chapterNumber) {
                     chapterNumber = chapterNumber[1];
                 }
-                // await this._fetchApiKey(mangaSlug, chapterNumber);
                 const data = await this.fetchGraphQL(request, operationName, query, variables);
                 return data;
             } else {
@@ -49,7 +46,6 @@ export default class MangaHub extends Connector {
         request.headers.set('x-sec-fetch-mode', 'navigate');
         request.headers.set('Upgrade-Insecure-Requests', 1);
         request.headers.delete('x-origin');
-        //request.headers.delete('x-mhub-access');
         let data = await this.fetchDOM(request, 'div#mangadetail div.container-fluid div.row h1');
         let id = uri.pathname.split('/').filter(e => e).pop();
         let title = data[0].firstChild.textContent.trim();
@@ -83,7 +79,6 @@ export default class MangaHub extends Connector {
         }`;
         let data = await this._fetchGraphQLWithoutRateLimit(this.apiURL, undefined, gql, undefined);
         return data.manga.chapters.map(chapter => {
-            // .padStart( 4, '0' )
             let title = `Ch. ${chapter.number} - ${chapter.title}`;
             return {
                 id: chapter.number, // chapter.id, chapter.slug,
@@ -109,7 +104,6 @@ export default class MangaHub extends Connector {
         request.headers.set('x-sec-fetch-dest', 'image');
         request.headers.set('x-sec-fetch-mode', 'no-cors');
         request.headers.delete('x-origin');
-        //request.headers.delete('x-mhub-access');
         let response = await fetch(request);
         let data = await response.blob();
         data = await this._blobToBuffer(data);

--- a/src/web/mjs/connectors/MangaHub.mjs
+++ b/src/web/mjs/connectors/MangaHub.mjs
@@ -1,6 +1,6 @@
 import Connector from '../engine/Connector.mjs';
 import Cookie from '../engine/Cookie.mjs';
-import HeaderGenerator from '../engine/HeaderGenerator.mjs';
+//import HeaderGenerator from '../engine/HeaderGenerator.mjs';
 import Manga from '../engine/Manga.mjs';
 
 export default class MangaHub extends Connector {
@@ -20,66 +20,6 @@ export default class MangaHub extends Connector {
         this.requestOptions.headers.set('Accept-Language', 'en-US,en;q=0.9');
     }
 
-    _randomInteger(min, max) {
-        return Math.floor(Math.random() * (max - min + 1)) + min;
-    }
-
-    async _updateCookies(chapterNumber) {
-        const { remote } = require('electron');
-
-        const now = new Date().getTime();
-        if (chapterNumber > 1) {
-            chapterNumber -= 1;
-        }
-        const recently = {
-            url: this.url,
-            name: 'recently',
-            value: encodeURIComponent(`{"${now - this._randomInteger(0, 1200)}":{"mangaID":${this._randomInteger(1, 30000)},"number":${chapterNumber}}}`),
-            path: '/',
-            expirationDate: now + 2 * 31 * 24 * 60 * 60 * 1000
-        };
-        await remote.session.defaultSession.cookies.set(recently);
-    }
-
-    async _fetchApiKey(mangaSlug, chapterNumber) {
-        this.requestOptions.headers.set('x-user-agent', HeaderGenerator.randomUA());
-        let path = '';
-        if (mangaSlug && chapterNumber) {
-            await this._updateCookies(chapterNumber);
-            path = `${this.url}/manga/${mangaSlug}`;
-        } else {
-            path = `${this.url}/`;
-        }
-        const uri = new URL(path);
-        uri.searchParams.append('reloadKey', '1');
-        const request = new Request(uri, this.requestOptions);
-        request.headers.set('x-sec-fetch-dest', 'document');
-        request.headers.set('x-sec-fetch-mode', 'navigate');
-        request.headers.set('Upgrade-Insecure-Requests', 1);
-        request.headers.delete('x-origin');
-        request.headers.delete('x-mhub-access');
-        const response = await fetch(request);
-        const cookie = new Cookie(response.headers.get('x-set-cookie'));
-
-        if (mangaSlug && chapterNumber && !cookie.get('mhub_access')) {
-            const oldKey = this.requestOptions.headers.get('x-mhub-access');
-            await this._fetchApiKey(null, null);
-            if (!this.requestOptions.headers.get('x-mhub-access')) {
-                this.requestOptions.headers.set('x-mhub-access', oldKey);
-                throw new Error(`${this.label}: Can't update the API key!`);
-            }
-        } else {
-            this.requestOptions.headers.set('x-mhub-access', !cookie.get('mhub_access') ? '' : cookie.get('mhub_access'));
-        }
-    }
-
-    async _initializeConnector() {
-        await this._fetchApiKey(null, null);
-        if (!this.requestOptions.headers.get('x-mhub-access')) {
-            throw new Error(`${this.label}: Can't initialize the API key! Try selecting another manga from this connector!`);
-        }
-    }
-
     async _fetchGraphQLWithoutRateLimit(request, operationName, query, variables) {
         try {
             const data = await this.fetchGraphQL(request, operationName, query, variables);
@@ -94,7 +34,7 @@ export default class MangaHub extends Connector {
                 if (chapterNumber) {
                     chapterNumber = chapterNumber[1];
                 }
-                await this._fetchApiKey(mangaSlug, chapterNumber);
+               // await this._fetchApiKey(mangaSlug, chapterNumber);
                 const data = await this.fetchGraphQL(request, operationName, query, variables);
                 return data;
             } else {
@@ -109,7 +49,7 @@ export default class MangaHub extends Connector {
         request.headers.set('x-sec-fetch-mode', 'navigate');
         request.headers.set('Upgrade-Insecure-Requests', 1);
         request.headers.delete('x-origin');
-        request.headers.delete('x-mhub-access');
+        //request.headers.delete('x-mhub-access');
         let data = await this.fetchDOM(request, 'div#mangadetail div.container-fluid div.row h1');
         let id = uri.pathname.split('/').filter(e => e).pop();
         let title = data[0].firstChild.textContent.trim();
@@ -169,7 +109,7 @@ export default class MangaHub extends Connector {
         request.headers.set('x-sec-fetch-dest', 'image');
         request.headers.set('x-sec-fetch-mode', 'no-cors');
         request.headers.delete('x-origin');
-        request.headers.delete('x-mhub-access');
+        //request.headers.delete('x-mhub-access');
         let response = await fetch(request);
         let data = await response.blob();
         data = await this._blobToBuffer(data);

--- a/src/web/mjs/connectors/MangaHub.mjs
+++ b/src/web/mjs/connectors/MangaHub.mjs
@@ -1,5 +1,5 @@
 import Connector from '../engine/Connector.mjs';
-import Cookie from '../engine/Cookie.mjs';
+//import Cookie from '../engine/Cookie.mjs';
 //import HeaderGenerator from '../engine/HeaderGenerator.mjs';
 import Manga from '../engine/Manga.mjs';
 
@@ -34,7 +34,7 @@ export default class MangaHub extends Connector {
                 if (chapterNumber) {
                     chapterNumber = chapterNumber[1];
                 }
-               // await this._fetchApiKey(mangaSlug, chapterNumber);
+                // await this._fetchApiKey(mangaSlug, chapterNumber);
                 const data = await this.fetchGraphQL(request, operationName, query, variables);
                 return data;
             } else {

--- a/src/web/mjs/engine/Request.mjs
+++ b/src/web/mjs/engine/Request.mjs
@@ -543,7 +543,6 @@ export default class Request {
 
         if(details.responseHeaders['set-cookie'] || details.responseHeaders['Set-Cookie']) {
             Cookie.applyCrossSiteCookies(details.responseHeaders);
-            details.responseHeaders['x-set-cookie'] = details.responseHeaders['set-cookie'] || details.responseHeaders['Set-Cookie'];
         }
 
         return details;


### PR DESCRIPTION
* Fixes https://github.com/manga-download/hakuneko/issues/5199 

 They removed the need for an api key / x-mhub-access . Other dependent websites works fine on HN. I kept the unrelated stuff untouched. I got rate limited by Cloudflare check (?) after a while, maybe because i was testing the other websites. Reopening HN worked. May need further investigations.