### PR TITLE
Manganato : change Regex for clipboard

### DIFF
--- a/src/web/mjs/connectors/MangaNel.mjs
+++ b/src/web/mjs/connectors/MangaNel.mjs
@@ -33,7 +33,7 @@ export default class MangaNel extends Connector {
 
     canHandleURI(uri) {
         // Test: https://regex101.com/r/aPR3zy/3/tests
-        return /^(chap)?(read)?manganato\.com$/.test(uri.hostname);
+        return /^(chap|read)?manganato\.com$/.test(uri.hostname);
     }
 
     async _getMangaFromURI(uri) {

--- a/src/web/mjs/connectors/MangaNel.mjs
+++ b/src/web/mjs/connectors/MangaNel.mjs
@@ -33,7 +33,7 @@ export default class MangaNel extends Connector {
 
     canHandleURI(uri) {
         // Test: https://regex101.com/r/aPR3zy/3/tests
-        return /^(m\.|chap\.)?(read)?manganato\.com$/.test(uri.hostname);
+        return /^(chap)?(read)?manganato\.com$/.test(uri.hostname);
     }
 
     async _getMangaFromURI(uri) {


### PR DESCRIPTION
* m subdomain doesnt work anymore
* no more chap and read subdomains they are full domains (readmanganato redirect to chapmanganato anyway)
* Support manganato.com, readmanganato.com and chapmanganato.com
* Fixes https://github.com/manga-download/hakuneko/issues/5072 fixes https://github.com/manga-download/hakuneko/issues/5178