### PR TITLE
FlatManga : remove unnecessary escaping from regex

### DIFF
--- a/src/web/mjs/connectors/templates/FlatManga.mjs
+++ b/src/web/mjs/connectors/templates/FlatManga.mjs
@@ -59,7 +59,7 @@ export default class FlatManga extends Connector {
             let title = (this.queryChapterTitle ? element.querySelector(this.queryChapterTitle) : element).textContent.replace(manga.title, '');
             let mangaTitle = manga.title.replace(/\s*-\s*RAW$/, '');
             //escape all special characters used in Javascript regexes
-            title = title.replace(new RegExp(mangaTitle.replace(/[\*\^\$\.\|\?\+\-\(\)\[\]\{\}\\\/]/g, '\\$&')), '');
+            title = title.replace(new RegExp(mangaTitle.replace(/[*^.|$?+\-()[\]\{\}\\\/]/g, '\\$&')), '');
             title = title.replace(/^\s*-\s*/, '');
             title = title.replace(/-\s*-\s*Read\s*Online\s*$/, '');
             title = title.trim();


### PR DESCRIPTION
According to Lint processor in https://github.com/manga-download/hakuneko/pull/5262/, in our case escaping is useless on * ^ $ . | ? + ( ) and [. Confirmed by an online tester and with further testing on depending connectors. 

When you want to be careful and you are too careful.