### PR TITLE
PDF Export Fix soft lock when encountering broken images

### DIFF
--- a/src/web/mjs/engine/Storage.mjs
+++ b/src/web/mjs/engine/Storage.mjs
@@ -516,11 +516,11 @@ export default class Storage {
      * Add a single image as PDF page to the given document.
      */
     async _addImageToPDF(pdfDocument, page) {
-        let bitmap = await new Promise(resolve => {
+        let bitmap = await new Promise((resolve, reject) => {
             let img = new Image();
             img.onload = () => resolve(img);
+            img.onerror = () => reject(new Error('Failed to load image!'));
             img.src = URL.createObjectURL(page.data);
-            resolve(img)
         });
         let pdfImgType = this._pdfImageType(page);
         let blob;

--- a/src/web/mjs/engine/Storage.mjs
+++ b/src/web/mjs/engine/Storage.mjs
@@ -504,52 +504,44 @@ export default class Storage {
      * Callback will be executed after completion and provided with an array of errors (or an empty array when no errors occured).
      */
     async _saveChapterPagesPDF(pdf, pageData) {
-        try {
-            var doc = new PDFDocument({ autoFirstPage: false });
-            doc.pipe(this.fs.createWriteStream(pdf));
-            for (let page of pageData) {
-                await this._addImageToPDF(doc, page);
-            }
-            doc.end();
-        } catch (error) {
-            throw error
+        var doc = new PDFDocument({ autoFirstPage: false });
+        doc.pipe(this.fs.createWriteStream(pdf));
+        for (let page of pageData) {
+            await this._addImageToPDF(doc, page);
         }
+        doc.end();
     }
 
     /**
      * Add a single image as PDF page to the given document.
      */
     async _addImageToPDF(pdfDocument, page) {
-        try {
-            let bitmap = await new Promise(resolve => {
-                let img = new Image();
-                img.onload = () => resolve(img);
-                img.src = URL.createObjectURL(page.data);
-                resolve(img)
+        let bitmap = await new Promise(resolve => {
+            let img = new Image();
+            img.onload = () => resolve(img);
+            img.src = URL.createObjectURL(page.data);
+            resolve(img)
+        });
+        let pdfImgType = this._pdfImageType(page);
+        let blob;
+        if (!pdfImgType) {
+            pdfImgType = 'JPEG';
+            let canvas = document.createElement('canvas');
+            canvas.width = bitmap.width;
+            canvas.height = bitmap.height;
+            let ctx = canvas.getContext('2d');
+            ctx.drawImage(bitmap, 0, 0);
+            blob = await new Promise(resolve => {
+                canvas.toBlob(data => resolve(data), 'image/jpeg', 0.90);
             });
-            let pdfImgType = this._pdfImageType(page);
-            let blob;
-            if (!pdfImgType) {
-                pdfImgType = 'JPEG';
-                let canvas = document.createElement('canvas');
-                canvas.width = bitmap.width;
-                canvas.height = bitmap.height;
-                let ctx = canvas.getContext('2d');
-                ctx.drawImage(bitmap, 0, 0);
-                blob = await new Promise(resolve => {
-                    canvas.toBlob(data => resolve(data), 'image/jpeg', 0.90);
-                });
-            } else {
-                blob = page.data;
-            }
-    
-            let bytes = await this._blobToBytes(blob);
-            let pdfTargetWidth = this.pdfTargetHeight * bitmap.width / bitmap.height;
-            pdfDocument.addPage({ size: [pdfTargetWidth, this.pdfTargetHeight] });
-            pdfDocument.image(bytes.buffer, 0, 0, { width: pdfTargetWidth, height: this.pdfTargetHeight });
-        } catch (error) {
-            throw error
+        } else {
+            blob = page.data;
         }
+
+        let bytes = await this._blobToBytes(blob);
+        let pdfTargetWidth = this.pdfTargetHeight * bitmap.width / bitmap.height;
+        pdfDocument.addPage({ size: [pdfTargetWidth, this.pdfTargetHeight] });
+        pdfDocument.image(bytes.buffer, 0, 0, { width: pdfTargetWidth, height: this.pdfTargetHeight });
     }
 
     /**


### PR DESCRIPTION
- Fixes #5380 .

With this pull request downloads that get stuck when exporting to PDF will now error out as expected and continue with the rest of the download.