### PR TITLE
MangaCross : Fix error when trailing slash url

### DIFF
--- a/src/web/mjs/connectors/MangaCross.mjs
+++ b/src/web/mjs/connectors/MangaCross.mjs
@@ -14,7 +14,7 @@ export default class MangaCross extends Connector {
     async _getMangaFromURI(uri) {
         let request = new Request(uri, this.requestOptions);
         let data = await this.fetchDOM(request, 'head title');
-        let id = uri.pathname.split('/').pop();
+        let id = uri.pathname.split('/').filter(Boolean).pop();
         let title = data[0].textContent.split('|')[0].trim();
         return new Manga(this, id, title);
     }


### PR DESCRIPTION
The MangaCross plugin will fail if a url with an ending "/" is presented, since the trailing slash plus pop() will return a blank array. We can avoid this by filtering the array list to only show booleans before using pop(), thus always returning the manga id whether the URL is ending with a / or not. This code is probably not ideal so it's totally okay to decline and fix this with a better alternative.

Test links:
https://mangacross.jp/comics/okaeri (Will work normally with the original plugin)
https://mangacross.jp/comics/okaeri/ (Will not work since it tries to call a json without name (due to pop() returning blank)