### PR TITLE
ComicBrise : Fix truncated baseURL

### DIFF
--- a/src/web/mjs/connectors/ComicBrise.mjs
+++ b/src/web/mjs/connectors/ComicBrise.mjs
@@ -42,7 +42,7 @@ export default class ComicBrise extends SpeedBinb {
                 };
             });
     }
-   _getPageList_v016061( imageConfigurtions, baseURL ) {
+    _getPageList_v016061( imageConfigurtions, baseURL ) {
         baseURL += baseURL.endsWith('/') ? '' : '/';
         let pageLinks = imageConfigurtions.map( element => this.createConnectorURI( this.getAbsolutePath( element.dataset.ptimg, baseURL ) ) );
         return Promise.resolve( pageLinks );

--- a/src/web/mjs/connectors/ComicBrise.mjs
+++ b/src/web/mjs/connectors/ComicBrise.mjs
@@ -42,4 +42,9 @@ export default class ComicBrise extends SpeedBinb {
                 };
             });
     }
+   _getPageList_v016061( imageConfigurtions, baseURL ) {
+        baseURL += baseURL.endsWith('/') ? '' : '/';
+        let pageLinks = imageConfigurtions.map( element => this.createConnectorURI( this.getAbsolutePath( element.dataset.ptimg, baseURL ) ) );
+        return Promise.resolve( pageLinks );
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/manga-download/hakuneko/issues/5440

Speedbind template bug? In _getPageList_v016061, if baseURL ends up with no '/', getAbsolutePath truncate the last part of the url, so we cant fetch the JSON after

Ex; "https://www.comic-brise.com/comic_ep/tenfollo/ep/8" become "https://www.comic-brise.com/comic_ep/tenfollo/ep/" and we try to fetch 
"https://www.comic-brise.com/comic_ep/tenfollo/ep/data/0001.ptimg.json" instead of  "https://www.comic-brise.com/comic_ep/tenfollo/ep/8/data/0001.ptimg.json"

I dont want to mess with Speedbind so fix is only for that connector.