### PR TITLE
SaveAsPdf : Workaround for PDFKIT png lib bug

### DIFF
--- a/src/web/mjs/engine/Storage.mjs
+++ b/src/web/mjs/engine/Storage.mjs
@@ -855,9 +855,9 @@ export default class Storage {
         if (image.type === 'image/jpeg') {
             return 'JPEG';
         }
-        if (image.type === 'image/png') {
-            return 'PNG';
-        }
+        //if (image.type === 'image/png') {
+        //    return 'PNG';
+        //}
         return undefined;
     }
 


### PR DESCRIPTION
What error : 
---------------
Max stack exceeded when creating PDF

Reproduce the error : 
--------------------------------
Try so save as PDF this chapter : https://bato.to/chapter/1452754. We get a stack overflow when adding the last page which is a 4.5MB png.

It turns out the error is in the PNG lib included in our PDFKIT version (when parsing tExT chunk). 

JPG files doesnt have this problem apparently. Maybe because PDFKit handle them properly or just because we dont find exceeding 4MB easily ? Need further testing .

Proposed workaround : 
---------------------------
Force JPG conversion if image is not jpeg (its already the case for WEBP, now it will be the same for PNG).

Another possibility would be try.catch page addition and convert the png only in case of error.

References : Fixes https://github.com/manga-download/hakuneko/issues/5450