### PR TITLE
IsekaiScan : change url

### DIFF
--- a/src/web/mjs/connectors/IsekaiScan.mjs
+++ b/src/web/mjs/connectors/IsekaiScan.mjs
@@ -5,8 +5,8 @@ export default class IsekaiScan extends WordPressMadara {
     constructor() {
         super();
         super.id = 'isekaiscan';
-        super.label = 'IsekaiScan';
+        super.label = 'IsekaiScan.to';
         this.tags = [ 'manga', 'english' ];
-        this.url = 'https://isekaiscan.com';
+        this.url = 'https://isekaiscan.to';
     }
 }


### PR DESCRIPTION
Not sure its the same IsekaiScans but the number of mangas is similar to the old one (77xx) and old one is dead for months. Fixes https://github.com/manga-download/hakuneko/issues/5574