### PR TITLE
fix(connector): Ganma - vacant chapter titles become undefined

### DIFF
--- a/src/web/mjs/connectors/Ganma.mjs
+++ b/src/web/mjs/connectors/Ganma.mjs
@@ -7,7 +7,7 @@ export default class Ganma extends Connector {
         super();
         super.id = 'ganma';
         super.label = 'GANMA!';
-        this.tags = [ 'manga', 'japanese' ];
+        this.tags = ['manga', 'japanese'];
         this.url = 'https://ganma.jp';
         this.requestOptions.headers.set('x-from', this.url);
     }
@@ -62,7 +62,7 @@ export default class Ganma extends Connector {
             .map((chapter, index) => {
                 return {
                     id: chapter.id,
-                    title: ((chapter.number || index + 1) + ': 【' + chapter.title + '】 ' + chapter.subtitle).trim()
+                    title: ((chapter.number || index + 1) + ': 【' + chapter.title + '】 ' + (chapter.subtitle || "")).trim()
                 };
             });
     }
@@ -71,7 +71,7 @@ export default class Ganma extends Connector {
         const uri = new URL('/api/1.0/magazines/web/' + chapter.manga.id, this.url);
         const request = new Request(uri, this.requestOptions);
         let data = await this.fetchJSON(request);
-        data = data.root.items.find(item => item.id === chapter.id ).page;
+        data = data.root.items.find(item => item.id === chapter.id).page;
         return data.files.map(image => this.getAbsolutePath(image + '?' + data.token, data.baseUrl));
     }
 }

--- a/src/web/mjs/connectors/Ganma.mjs
+++ b/src/web/mjs/connectors/Ganma.mjs
@@ -7,7 +7,7 @@ export default class Ganma extends Connector {
         super();
         super.id = 'ganma';
         super.label = 'GANMA!';
-        this.tags = ['manga', 'japanese'];
+        this.tags = [ 'manga', 'japanese' ];
         this.url = 'https://ganma.jp';
         this.requestOptions.headers.set('x-from', this.url);
     }
@@ -71,7 +71,7 @@ export default class Ganma extends Connector {
         const uri = new URL('/api/1.0/magazines/web/' + chapter.manga.id, this.url);
         const request = new Request(uri, this.requestOptions);
         let data = await this.fetchJSON(request);
-        data = data.root.items.find(item => item.id === chapter.id).page;
+        data = data.root.items.find(item => item.id === chapter.id ).page;
         return data.files.map(image => this.getAbsolutePath(image + '?' + data.token, data.baseUrl));
     }
 }


### PR DESCRIPTION
A fix for the Ganma connector: When a chapter doesn't have a subtitle, it shows and downloads as `undefined`.

Example: [https://ganma.jp/kotori](https://ganma.jp/kotori)

<img width="526" alt="截屏2023-03-22 21 23 02" src="https://user-images.githubusercontent.com/10600318/227029025-f4089f2c-a960-45f9-8be2-719b2d01333d.png">
