### PR TITLE
JayMana : change URL + fix clipboard

### DIFF
--- a/src/web/mjs/connectors/Jmana1.mjs
+++ b/src/web/mjs/connectors/Jmana1.mjs
@@ -7,7 +7,7 @@ export default class Jmana1 extends Connector {
         super.id = 'jmana1';
         super.label = '제이마나 (Jaymana)';
         this.tags = [ 'manga', 'korean' ];
-        this.url = 'https://jmana1.net';
+        this.url = 'https://kr21.jmana.one';
         this.requestOptions.headers.set('x-referer', this.url);
 
         this.config = {
@@ -24,7 +24,7 @@ export default class Jmana1 extends Connector {
 
     async _getMangaFromURI(uri) {
         const id = uri.pathname + uri.search;
-        const title = uri.searchParams.get('bookname').trim();
+        const title = (await this.fetchDOM(new Request(uri, this.requestOptions), 'div.books-db-detail a.tit')).pop().text.trim();
         return new Manga(this, id, title);
     }
 


### PR DESCRIPTION
Manga pages apparently have 2 formats : 

h--ps://kr21.jmana.one/book?bookid=4681
h--ps://kr21.jmana.one/comic_list_title?bookname=%EC%9B%90%ED%94%BC%EC%8A%A4%28ONE+PIECE%29

Clipboard was getting title from search param which is missing in first url. Page layout is the same for both, using CSS is fine.

Fixes https://github.com/manga-download/hakuneko/issues/5652