### PR TITLE
DownloadJob : FFMPEG whitelist protocols

### DIFF
--- a/src/web/mjs/engine/DownloadJob.mjs
+++ b/src/web/mjs/engine/DownloadJob.mjs
@@ -157,7 +157,7 @@ export default class DownloadJob extends EventTarget {
      */
     _downloadPlaylistHLS( episode, directory, callback ) {
         let ffmpeg = {
-            command: ['ffmpeg', '-loglevel', 'error', '-allowed_extensions', 'ALL'],
+            command: ['ffmpeg', '-loglevel', 'error', '-allowed_extensions', 'ALL', '-protocol_whitelist', 'concat,file,http,https,tcp,tls,crypto'],
             inputs: [],
             maps: ['-map', '0:v', '-map', '0:a'],
             metas: []


### PR DESCRIPTION
If you want to download m3u8 using FFMPEG, you encounter some errors 

https://cdn.discordapp.com/attachments/581629183159959584/1097091076310974524/image.png

The solution is whitelisting protocols in FFMPEG command line

```-protocol_whitelist concat,file,http,https,tcp,tls,crypto```

Its affecting many video hosters, like Filemoon (the only one that works for 9Anime).

Not sure what are security implications here.