### PR TITLE
Update EightMuses.mjs

### DIFF
--- a/src/web/mjs/connectors/EightMuses.mjs
+++ b/src/web/mjs/connectors/EightMuses.mjs
@@ -26,12 +26,14 @@ export default class EightMuses extends Connector {
 
     async _getChapters(manga) {
         let request = new Request(new URL(manga.id, this.url), this.requestOptions);
-        let data = await this.fetchDOM(request, 'div#top-menu div.top-menu-breadcrumb ol li a');
-        return [ {
-            id: manga.id,
-            title: data.slice(2).map(element => element.text.trim()).join(' → '),
-            language: ''
-        } ];
+        let data = await this.fetchDOM(request, 'div#content div div.gallery a[title]');
+        return data.map(element => {
+            return {
+                id: this.getRootRelativeOrAbsoluteLink(element, this.url),
+                title: element.text.trim(),
+                language: ''
+            };
+        });
     }
 
     async _getPages(chapter) {


### PR DESCRIPTION
Previously, we have to paste only the comics URL from 8muses which contain pictures. After my code changes. it is successfully, fetching all the comics from a album URL.

E.g. - If you paste below URL, it will successfully download All immediate child comics (Only if child comics does not have any more child comics i.e. issues)

https://comics.8muses.com/comics/album/ShadBase-Comics 