### PR TITLE
KomikLab : split into 2 websites

### DIFF
--- a/src/web/mjs/connectors/KomikLab.mjs
+++ b/src/web/mjs/connectors/KomikLab.mjs
@@ -5,8 +5,8 @@ export default class KomikLab extends WordPressMangastream {
     constructor() {
         super();
         super.id = 'komiklab';
-        super.label = 'KomikLab';
-        this.tags = ['manga', 'indonesian'];
+        super.label = 'KomikLab (English)';
+        this.tags = ['manga', 'english'];
         this.url = 'https://komiklab.com';
         this.path = '/manga/list-mode/';
     }

--- a/src/web/mjs/connectors/KomikLabIND.mjs
+++ b/src/web/mjs/connectors/KomikLabIND.mjs
@@ -1,0 +1,17 @@
+import WordPressMangastream from './templates/WordPressMangastream.mjs';
+
+export default class KomikLabIND extends WordPressMangastream {
+
+    constructor() {
+        super();
+        super.id = 'komiklabind';
+        super.label = 'KomikLab (Indo)';
+        this.tags = ['manga', 'indonesian'];
+        this.url = 'https://komiklab.net';
+        this.path = '/manga/list-mode/';
+    }
+
+    get icon() {
+        return '/img/connectors/komiklab';
+    }
+}


### PR DESCRIPTION
* The original (.com) is now english only
* The second (.net) is for indonesian work

Fixes https://github.com/manga-download/hakuneko/issues/5799