### PR TITLE
Mangabaz: update url

### DIFF
--- a/src/web/mjs/connectors/Mangabaz.mjs
+++ b/src/web/mjs/connectors/Mangabaz.mjs
@@ -7,6 +7,6 @@ export default class Mangabaz extends WordPressMadara {
         super.id = 'mangabaz';
         super.label = 'Mangabaz';
         this.tags = [ 'manga', 'webtoon', 'turkish' ];
-        this.url = 'https://mangabaz.com';
+        this.url = 'https://mangabaz.net';
     }
 }


### PR DESCRIPTION
https://mangabaz.com returns a maintenance page
I'm pretty sure I updated the right connector since there is only one known "Mangabaz" and their site is https://mangabaz.net
https://mangadex.org/groups?q=Mangabaz
https://www.mangaupdates.com/groups.html?search=Mangabaz