### PR TITLE
FIX: ColoredManga - fix manga list

### DIFF
--- a/src/web/mjs/connectors/ColoredManga.mjs
+++ b/src/web/mjs/connectors/ColoredManga.mjs
@@ -9,4 +9,8 @@ export default class ColoredManga extends WordPressMadara {
         this.tags = ['manga', 'english'];
         this.url = 'https://coloredmanga.com';
     }
+
+    _createMangaRequest(page) {
+        return new Request(new URL(`/manga/page/${page}/`, this.url), this.requestOptions);
+    }
 }


### PR DESCRIPTION
override Madara _createMangaRequest to get manga by fetching list page and not the bugged madara endpoint.

Fixes https://github.com/manga-download/hakuneko/issues/5890