### PR TITLE
FIX: Readmanga/Mintmanga/Selfmanga chapter list

### DIFF
--- a/src/web/mjs/connectors/ReadManga.mjs
+++ b/src/web/mjs/connectors/ReadManga.mjs
@@ -66,7 +66,7 @@ export default class ReadManga extends Connector {
         let data = await this.fetchDOM(request, 'div#mangaBox' );
         let content = data[0];
         let mangaTitle = content.querySelector('h1.names span.name').innerText.trim();
-        let chapterList = [...content.querySelectorAll('div.chapters-link table tr td a')];
+        let chapterList = [...content.querySelectorAll('div#chapters-list table tr td a')];
         return chapterList.map(element => {
             return {
                 id: this.getRootRelativeOrAbsoluteLink(element, this.url),

--- a/src/web/mjs/connectors/SelfManga.mjs
+++ b/src/web/mjs/connectors/SelfManga.mjs
@@ -7,7 +7,7 @@ export default class SelfManga extends ReadManga {
         super.id = 'selfmanga';
         super.label = 'SelfManga';
         this.tags = [ 'manga', 'russian' ];
-        this.url = 'https://selfmanga.ru';
+        this.url = 'https://selfmanga.live';
         this.links = {
             login: 'https://grouple.co/internal/auth/login'
         };


### PR DESCRIPTION
- Changed queryselector (wrong div name was not returning chapters, rendering the plugin unusable)
- Updated Selfmanga URL