### PR TITLE
HeaderGenerator: restrict to more recent browser versions

### DIFF
--- a/src/web/mjs/engine/HeaderGenerator.mjs
+++ b/src/web/mjs/engine/HeaderGenerator.mjs
@@ -40,13 +40,13 @@ export default class HeaderGenerator {
 
     static get _browserChrome() {
         let $ = HeaderGenerator;
-        let version = $._rn( 50, 66 ) + '.' + $._rn( 0, 99 ) + '.' + $._rn( 0, 9999 ) + '.' + $._rn( 0, 999 );
+        let version = $._rn( 105, 113 ) + '.' + $._rn( 0, 99 ) + '.' + $._rn( 0, 9999 ) + '.' + $._rn( 0, 999 );
         return 'Mozilla/5.0 (' + $._os + ') AppleWebKit/537.36 (KHTML, like Gecko) Chrome/' + version + ' Safari/537.36';
     }
 
     static get _browserFirefox() {
         let $ = HeaderGenerator;
-        let version = $._rn( 45, 60 );
+        let version = $._rn( 105, 114 );
         return 'Mozilla/5.0 (' + $._os + '; rv:' + version + '.0) Gecko/20100101 Firefox/' + version + '.0';
     }
 


### PR DESCRIPTION
Some website gives "browser too old" errors because of Cloudflare.

Somehow, depending on the protection level, we can mitigate those issues by generating a good user agent with more recent Chrome/Firefox versions.

This PR only makes sure we generate user-agents with browser major versions >= 105 for Chrome and Firefox, and =< 113 or 114 (Current major version for FF / Chrome)

Those numbers are arbitrarily chosen, feel free to voice your concern.

This is more fingertprintable because there are less combinations :/