### PR TITLE
FIX : SushiScans : cloudflare workaround

### DIFF
--- a/src/web/mjs/connectors/SushiScans.mjs
+++ b/src/web/mjs/connectors/SushiScans.mjs
@@ -1,4 +1,5 @@
 import WordPressMangastream from './templates/WordPressMangastream.mjs';
+import HeaderGenerator from '../engine/HeaderGenerator.mjs';
 
 export default class SushiScans extends WordPressMangastream {
 
@@ -9,6 +10,7 @@ export default class SushiScans extends WordPressMangastream {
         this.tags = [ 'manga', 'french' ];
         this.url = 'https://sushiscan.net';
         this.path = '/manga/list-mode/';
+        this.requestOptions.headers.set('x-referer', this.url);
     }
 
     async _getPages(chapter) {
@@ -26,7 +28,21 @@ export default class SushiScans extends WordPressMangastream {
         const uri = new URL(chapter.id, this.url);
         let request = new Request(uri, this.requestOptions);
         let data = await Engine.Request.fetchUI(request, script);
+        data = data.filter(link => !link.includes('histats.com'));
+
         // HACK: bypass 'i0.wp.com' image CDN to ensure original images are loaded directly from host
-        return data.map(link => this.getAbsolutePath(link, request.url).replace(/\/i\d+\.wp\.com/, '')).filter(link => !link.includes('histats.com'));
+        return data.map(link => this.createConnectorURI(this.getAbsolutePath(link, request.url).replace(/\/i\d+\.wp\.com/, '')));
+    }
+
+    async _handleConnectorURI(payload) {
+        await this.wait(1500);
+        let request = new Request(payload, this.requestOptions);
+        request.headers.set('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8');
+        request.headers.set('x-user-agent', HeaderGenerator.randomUA());
+        let response = await fetch(request);
+        let data = await response.blob();
+        data = await this._blobToBuffer(data);
+        this._applyRealMime(data);
+        return data;
     }
 }


### PR DESCRIPTION
Somehow, using the updated HeaderGenerator (https://github.com/manga-download/hakuneko/pull/5938) and  setting the useragent and stuff give good results, like being able to download an an entire volume, or update manga list. 

We still got errors 403 but not like before, its still an improvement

![image](https://github.com/manga-download/hakuneko/assets/10671518/8e3915c9-becb-4902-b382-998d1c9131d0)

OFC this needs https://github.com/manga-download/hakuneko/pull/5938 to work properly

See https://github.com/manga-download/hakuneko/issues/5615