### PR TITLE
LegacyScans: change to Mangastream

### DIFF
--- a/src/web/mjs/connectors/LegacyScans.mjs
+++ b/src/web/mjs/connectors/LegacyScans.mjs
@@ -1,6 +1,6 @@
-import WordPressMadara from './templates/WordPressMadara.mjs';
+import WordPressMangastream from './templates/WordPressMangastream.mjs';
 
-export default class LegacyScans extends WordPressMadara {
+export default class LegacyScans extends WordPressMangastream {
 
     constructor() {
         super();
@@ -8,5 +8,9 @@ export default class LegacyScans extends WordPressMadara {
         super.label = 'Legacy-Scans';
         this.tags = ['webtoon', 'french'];
         this.url = 'https://legacy-scans.com';
+        this.path = '/manga/list-mode/';
+
+        this.queryMangas = 'div.postbody div.soralist ul li a.series';
+        this.queryChapters = 'div#chapterlist ul li a';
     }
 }

--- a/src/web/mjs/connectors/LegacyScans.mjs
+++ b/src/web/mjs/connectors/LegacyScans.mjs
@@ -10,7 +10,6 @@ export default class LegacyScans extends WordPressMangastream {
         this.url = 'https://legacy-scans.com';
         this.path = '/manga/list-mode/';
 
-        this.queryMangas = 'div.postbody div.soralist ul li a.series';
         this.queryChapters = 'div#chapterlist ul li a';
     }
 }

--- a/src/web/mjs/connectors/LegacyScans.mjs
+++ b/src/web/mjs/connectors/LegacyScans.mjs
@@ -9,7 +9,12 @@ export default class LegacyScans extends WordPressMangastream {
         this.tags = ['webtoon', 'french'];
         this.url = 'https://legacy-scans.com';
         this.path = '/manga/list-mode/';
+        this.requestOptions.headers.set('x-referer', this.url);
 
         this.queryChapters = 'div#chapterlist ul li a';
+    }
+
+    async _getPages(chapter) {
+        return (await super._getPages(chapter)).map(page => this.createConnectorURI(page));
     }
 }


### PR DESCRIPTION
[Legacyscans](https://legacy-scans.com) temporarily rebranded to [flamescans.fr](https://mangadex.org/group/0f82ec30-3b70-4870-b57c-5ebda3f5c770) but are now back with flamescans mangastream theme.

I can't test it though since they're using cloudflare. But I copied the code from the flamescans.fr connector, so everything *should* work out of the box.
