### PR TITLE
Update BlogTruyen.mjs

### DIFF
--- a/src/web/mjs/connectors/BlogTruyen.mjs
+++ b/src/web/mjs/connectors/BlogTruyen.mjs
@@ -8,7 +8,7 @@ export default class BlogTruyen extends Connector {
         super.id = 'blogtruyen';
         super.label = 'BlogTruyen';
         this.tags = [ 'manga', 'webtoon', 'vietnamese' ];
-        this.url = 'https://blogtruyen.vn';
+        this.url = 'https://blogtruyenmoi.com';
         this.requestOptions.headers.set('x-referer', this.url);
     }
 


### PR DESCRIPTION
Update Blogtruyen.vn -> Blogtruyenmoi.com
Originally Blogtruyen.vn, now Blogtruyenmoi.com