### PR TITLE
FIX: Mangadex: Throttle API requests for loading manga list

### DIFF
--- a/src/web/mjs/connectors/MangaDex.mjs
+++ b/src/web/mjs/connectors/MangaDex.mjs
@@ -76,7 +76,7 @@ export default class MangaDex extends Connector {
 
         while(lastCreatedAt) {
             await throttle;
-            throttle = new Promise(resolve => setTimeout(resolve, 250));
+            throttle = new Promise(resolve => setTimeout(resolve, this.config.throttleRequests.value));
 
             const uri = new URL('/manga', this.api);
             uri.searchParams.set('limit', `${limit}`);


### PR DESCRIPTION
Lack of throttling leads to connection refused errors. In tests throttling needed to be larger than 2 000 ms (I used the maximum of 10 000 ms).

