### PR TITLE
FIX Mangarawto pages order

### DIFF
--- a/src/web/mjs/connectors/Mangarawto.mjs
+++ b/src/web/mjs/connectors/Mangarawto.mjs
@@ -13,4 +13,20 @@ export default class Mangarawto extends Manga9 {
     canHandleURI(uri) {
         return /^mangaraw\.(to|vip|io)$/.test(uri.hostname);
     }
+
+    async _getPages(chapter) {
+        const script = `
+            new Promise(resolve => {
+                let pagelist = [...document.querySelectorAll('div.card-wrap img')].map(element => {
+                    return new URL(element.dataset.src, window.location).href
+                });
+                resolve(pagelist);
+            });
+        `;
+        const request = new Request(new URL(chapter.id, this.url), this.requestOptions);
+        const data = await Engine.Request.fetchUI(request, script);
+        return data.map(image => this.createConnectorURI(image));
+
+    }
+
 }


### PR DESCRIPTION
Somehow fetching image nodes by injecting a script fixes messed up image order and format.

Easy de-obfuscation but getting pages link by executing a function with an obfuscated name that can change is unreliable.

Fixes https://github.com/manga-download/hakuneko/issues/6064