### PR TITLE
FIX ComicFuz: download non crypted picture

### DIFF
--- a/src/web/mjs/connectors/ComicFuz.mjs
+++ b/src/web/mjs/connectors/ComicFuz.mjs
@@ -94,7 +94,7 @@ export default class ComicFuz extends Connector {
         } else {
             buffer = {
                 mimeType: response.headers.get('content-type'),
-                data: buffer
+                data: new Uint8Array(buffer)
             };
         }
         this._applyRealMime(buffer);


### PR DESCRIPTION
we werent able to apply real mime type on uncrypted pictures, because in that case we were using an arraybuffer and applyRealmime expect a Uint8Array