### PR TITLE
Fix Asura scans : url sometimes change

### DIFF
--- a/src/web/mjs/connectors/AsuraScans.mjs
+++ b/src/web/mjs/connectors/AsuraScans.mjs
@@ -7,11 +7,34 @@ export default class AsuraScans extends WordPressMangastream {
         super.id = 'asurascans';
         super.label = 'Asura Scans';
         this.tags = ['webtoon', 'english'];
-        this.url = 'https://www.asurascans.com';
+        this.config = {
+            url: {
+                label: 'URL',
+                description: 'This website changes between those two URL regularly.\n Please select the one to use',
+                input: 'select',
+                options: [
+                    { value: 'https://www.asurascans.com', name: 'asurascans.com' },
+                    { value: 'https://asura.gg', name: 'asura.gg' },
+                ],
+                value: 'https://www.asurascans.com'
+
+            }
+        };
         this.path = '/manga/list-mode/';
 
         this.queryPages = 'div#readerarea p img';
         this.requestOptions.headers.set('x-user-agent', 'Mozilla/5.0 (Linux; Android 9; Pixel) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4026.0 Mobile Safari/537.36');
+    }
+
+    get url() {
+        return this.config.url.value;
+    }
+
+    set url(value) {
+        if (this.config && value) {
+            this.config.url.value = value;
+            Engine.Settings.save();
+        }
     }
 
     async _getPages(chapter) {


### PR DESCRIPTION
Changed URL for asura scans from asurascans.com to asura.gg. This change happens from time to time since it's already been done but cancelled in the past, so I've added the possibility of switching from one to the other.