### PR TITLE
Save ComicInfo.xml in CBZ Files (Optional)

### DIFF
--- a/src/web/mjs/HakuNeko.mjs
+++ b/src/web/mjs/HakuNeko.mjs
@@ -8,6 +8,7 @@ import BookmarkManager from './engine/BookmarkManager.mjs';
 import ChaptermarkManager from './engine/ChaptermarkManager.mjs';
 import Connectors from './engine/Connectors.mjs';
 import DownloadManager from './engine/DownloadManager.mjs';
+import ComicInfoGenerator from './engine/ComicInfoGenerator.mjs';
 //import HistoryWorker from './engine/HistoryWorker.mjs'
 import Request from './engine/Request.mjs';
 import Settings from './engine/Settings.mjs';
@@ -32,6 +33,7 @@ export default class HakuNeko {
         this._connectors = new Connectors(ipc);
         this._storage = new Storage();
         this._bookmarkManager = new BookmarkManager(this._settings, new BookmarkImporter());
+        this._comicInfoGenerator = new ComicInfoGenerator();
         this._chaptermarkManager = new ChaptermarkManager(this._settings);
         this._discordPresence = new DiscordPresence(this._settings);
     }
@@ -61,6 +63,10 @@ export default class HakuNeko {
 
     get BookmarkManager() {
         return this._bookmarkManager;
+    }
+
+    get ComicInfoGenerator() {
+        return this._comicInfoGenerator;
     }
 
     get ChaptermarkManager() {

--- a/src/web/mjs/engine/ComicInfoGenerator.mjs
+++ b/src/web/mjs/engine/ComicInfoGenerator.mjs
@@ -1,5 +1,5 @@
 export default class ComicInfoGenerator {
-    static createComicInfoXML(series, title, pagesCount) {
+    createComicInfoXML(series, title, pagesCount) {
         series = this.escapeXML(series);
         title = this.escapeXML(title);
         return `<?xml version="1.0" encoding="utf-8"?>
@@ -10,20 +10,17 @@ export default class ComicInfoGenerator {
 </ComicInfo>`;
     }
 
-    static escapeXML(str) {
+    escapeXML(str) {
+        const symbols = {
+            '<': '&lt;',
+            '>': '&gt;',
+            '&': '&amp;',
+            '\'': '&apos;',
+            '"': '&quot;'
+        };
+
         return str.replace(/[<>&'"]/g, function (c) {
-            switch (c) {
-                case '<':
-                    return '&lt;';
-                case '>':
-                    return '&gt;';
-                case '&':
-                    return '&amp;';
-                case '\'':
-                    return '&apos;';
-                case '"':
-                    return '&quot;';
-            }
+            return symbols[c];
         });
     }
 }

--- a/src/web/mjs/engine/ComicInfoGenerator.mjs
+++ b/src/web/mjs/engine/ComicInfoGenerator.mjs
@@ -1,0 +1,29 @@
+export default class ComicInfoGenerator {
+    static createComicInfoXML(series, title, pagesCount) {
+        series = this.escapeXML(series);
+        title = this.escapeXML(title);
+        return `<?xml version="1.0" encoding="utf-8"?>
+<ComicInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Title>${title}</Title>
+    <Series>${series}</Series>
+    <PageCount>${pagesCount}</PageCount>
+</ComicInfo>`;
+    }
+
+    static escapeXML(str) {
+        return str.replace(/[<>&'"]/g, function (c) {
+            switch (c) {
+                case '<':
+                    return '&lt;';
+                case '>':
+                    return '&gt;';
+                case '&':
+                    return '&amp;';
+                case '\'':
+                    return '&apos;';
+                case '"':
+                    return '&quot;';
+            }
+        });
+    }
+}

--- a/src/web/mjs/engine/Settings.mjs
+++ b/src/web/mjs/engine/Settings.mjs
@@ -126,8 +126,8 @@ export default class Settings extends EventTarget {
         };
 
         this.includesComicFile = {
-            label: 'Include Comic File',
-            description: 'Include the comic file (.xml) in the chapter archive',
+            label: 'Include Comic File in CBZ',
+            description: 'Include a comic file (comicinfo.xml) in the chapter archive',
             input: types.checkbox,
             value: false
         };

--- a/src/web/mjs/engine/Settings.mjs
+++ b/src/web/mjs/engine/Settings.mjs
@@ -125,6 +125,13 @@ export default class Settings extends EventTarget {
             value: extensions.img
         };
 
+        this.includesComicFile = {
+            label: 'Include Comic File',
+            description: 'Include the comic file (.xml) in the chapter archive',
+            input: types.checkbox,
+            value: false
+        };
+
         this.recompressionFormat = {
             label: 'De-Scrambling Format',
             description: [

--- a/src/web/mjs/engine/Settings.mjs
+++ b/src/web/mjs/engine/Settings.mjs
@@ -125,13 +125,6 @@ export default class Settings extends EventTarget {
             value: extensions.img
         };
 
-        this.includesComicFile = {
-            label: 'Include Comic File in CBZ',
-            description: 'Include a comic file (comicinfo.xml) in the chapter archive',
-            input: types.checkbox,
-            value: false
-        };
-
         this.recompressionFormat = {
             label: 'De-Scrambling Format',
             description: [

--- a/src/web/mjs/engine/Storage.mjs
+++ b/src/web/mjs/engine/Storage.mjs
@@ -1,5 +1,4 @@
 import EbookGenerator from './EbookGenerator.mjs';
-import ComicInfoGenerator from './ComicInfoGenerator.mjs';
 import Chapter from './Chapter.mjs';
 
 const extensions = {
@@ -449,9 +448,7 @@ export default class Storage {
             }
             if (Engine.Settings.chapterFormat.value === extensions.cbz) {
                 this._createDirectoryChain(this.path.dirname(output));
-                let mangaName = chapter.manga.title;
-                let chapterName = chapter.title;
-                promise = this._saveChapterPagesCBZ(output, pageData, mangaName, chapterName)
+                promise = this._saveChapterPagesCBZ(output, pageData, chapter.manga.title, chapter.title)
                     .then(() => this._runPostChapterDownloadCommand(chapter, output));
             }
             if (Engine.Settings.chapterFormat.value === extensions.pdf) {
@@ -554,10 +551,8 @@ export default class Storage {
     _saveChapterPagesCBZ(archive, pageData, mangaName = '', chapterName = '') {
         let zip = new JSZip();
 
-        if (Engine.Settings.includesComicFile.value) {
-            let comicFile = ComicInfoGenerator.createComicInfoXML(mangaName, chapterName, pageData.length);
-            zip.file('ComicInfo.xml', comicFile);
-        }
+        let comicFile = Engine.ComicInfoGenerator.createComicInfoXML(mangaName, chapterName, pageData.length);
+        zip.file('ComicInfo.xml', comicFile);
 
         pageData.forEach(page => {
             zip.file(page.name, page.data);
@@ -901,5 +896,19 @@ export default class Storage {
                 }
             });
         });
+    }
+
+    /**
+     * Convenience function wrapping key value saving for pinned connectors
+     */
+    savePinnedConnectors(pinnedConnectors) {
+        return this.saveConfig('pinnedConnectors', pinnedConnectors);
+    }
+
+    /**
+     * Convenience function wrapping key value loading for pinned connectors
+     */
+    loadPinnedConnectors() {
+        return this.loadConfig('pinnedConnectors');
     }
 }

--- a/src/web/mjs/engine/Storage.mjs
+++ b/src/web/mjs/engine/Storage.mjs
@@ -1,4 +1,5 @@
 import EbookGenerator from './EbookGenerator.mjs';
+import ComicInfoGenerator from './ComicInfoGenerator.mjs';
 import Chapter from './Chapter.mjs';
 
 const extensions = {
@@ -448,7 +449,9 @@ export default class Storage {
             }
             if (Engine.Settings.chapterFormat.value === extensions.cbz) {
                 this._createDirectoryChain(this.path.dirname(output));
-                promise = this._saveChapterPagesCBZ(output, pageData)
+                let mangaName = chapter.manga.title;
+                let chapterName = chapter.title;
+                promise = this._saveChapterPagesCBZ(output, pageData, mangaName, chapterName)
                     .then(() => this._runPostChapterDownloadCommand(chapter, output));
             }
             if (Engine.Settings.chapterFormat.value === extensions.pdf) {
@@ -548,8 +551,14 @@ export default class Storage {
      * Create and save pages to the given archive file.
      * Callback will be executed after completion and provided with an array of errors (or an empty array when no errors occured).
      */
-    _saveChapterPagesCBZ(archive, pageData) {
+    _saveChapterPagesCBZ(archive, pageData, mangaName = '', chapterName = '') {
         let zip = new JSZip();
+
+        if (Engine.Settings.includesComicFile.value) {
+            let comicFile = ComicInfoGenerator.createComicInfoXML(mangaName, chapterName, pageData.length);
+            zip.file('ComicInfo.xml', comicFile);
+        }
+
         pageData.forEach(page => {
             zip.file(page.name, page.data);
         });

--- a/src/web/mjs/engine/Storage.mjs
+++ b/src/web/mjs/engine/Storage.mjs
@@ -897,18 +897,4 @@ export default class Storage {
             });
         });
     }
-
-    /**
-     * Convenience function wrapping key value saving for pinned connectors
-     */
-    savePinnedConnectors(pinnedConnectors) {
-        return this.saveConfig('pinnedConnectors', pinnedConnectors);
-    }
-
-    /**
-     * Convenience function wrapping key value loading for pinned connectors
-     */
-    loadPinnedConnectors() {
-        return this.loadConfig('pinnedConnectors');
-    }
 }


### PR DESCRIPTION
**Description:**
This pull request introduces a new feature to enhance the settings functionality by adding an option to save a ComicInfo.xml file within the CBZ files. This option is disabled by default to maintain backward compatibility.

**Purpose:**
The ComicInfo.xml file provides valuable additional information about the comics, benefiting users of popular comic readers like ComicRack, ComicZeal, and Chunky. By including this file, the readers can display detailed information about the comics, leading to improved grouping and organization.

<img width="476" alt="image" src="https://github.com/manga-download/hakuneko/assets/5881027/413f1caa-117a-4799-82b3-8407c231647f">



<img width="279" alt="image" src="https://github.com/manga-download/hakuneko/assets/5881027/ae797140-cbfc-4c77-b5b2-ab40a2ee0437">


<img width="999" alt="image" src="https://github.com/manga-download/hakuneko/assets/5881027/0eabb303-cb72-4e7d-988b-91a726a7f3a1">
