### PR TITLE
FIX Katakomik: change domain

### DIFF
--- a/src/web/mjs/connectors/Katakomik.mjs
+++ b/src/web/mjs/connectors/Katakomik.mjs
@@ -6,11 +6,7 @@ export default class Katakomik extends WordPressMangastream {
         super.id = 'katakomik';
         super.label = 'Katakomik';
         this.tags = ['webtoon', 'indonesian'];
-        this.url = 'https://www.katakomik.my.id';
-
-        this.queryMangas = 'div.bsx a';
-        this.queryChapters = 'div.eph-num a';
-        this.queryChaptersTitle = 'span.chapternum';
-        this.queryPages = 'img.ts-main-image.curdown';
+        this.url = 'https://katakomik.online';
+        this.path = '/manga/list-mode/';
     }
 }


### PR DESCRIPTION
and revert to default mangastream values

Fixes https://github.com/manga-download/hakuneko/issues/6110