### PR TITLE
FIX : AsuraScans  domain as a setting

### DIFF
--- a/src/web/mjs/connectors/AsuraScans.mjs
+++ b/src/web/mjs/connectors/AsuraScans.mjs
@@ -7,10 +7,28 @@ export default class AsuraScans extends WordPressMangastream {
         super.id = 'asurascans';
         super.label = 'Asura Scans';
         this.tags = ['webtoon', 'english'];
-        this.url = 'https://asura.gg';
         this.path = '/manga/list-mode/';
         this.queryPages = 'div#readerarea p img';
         this.requestOptions.headers.set('x-user-agent', 'Mozilla/5.0 (Linux; Android 9; Pixel) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4026.0 Mobile Safari/537.36');
+        this.config = {
+            url: {
+                label: 'URL',
+                description: `This website change domains regularly.\nThis is the default URL which can also be manually set by the user.`,
+                input: 'text',
+                value: 'https://asura.nacm.xyz'
+            }
+        };
+    }
+
+    get url() {
+        return this.config.url.value;
+    }
+
+    set url(value) {
+        if (this.config && value) {
+            this.config.url.value = value;
+            Engine.Settings.save();
+        }
     }
 
     async _getPages(chapter) {

--- a/src/web/mjs/connectors/AsuraScansTR.mjs
+++ b/src/web/mjs/connectors/AsuraScansTR.mjs
@@ -1,6 +1,6 @@
-import AsuraScans from './AsuraScans.mjs';
+import WordPressMangastream from './templates/WordPressMangastream.mjs';
 
-export default class AsuraScansTR extends AsuraScans {
+export default class AsuraScansTR extends WordPressMangastream {
 
     constructor() {
         super();
@@ -8,9 +8,24 @@ export default class AsuraScansTR extends AsuraScans {
         super.label = 'Asura Scans (TR)';
         this.tags = ['webtoon', 'turkish'];
         this.url = 'https://asurascanstr.com';
+        this.path = '/manga/list-mode/';
+        this.queryPages = 'div#readerarea p img';
+        this.requestOptions.headers.set('x-user-agent', 'Mozilla/5.0 (Linux; Android 9; Pixel) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4026.0 Mobile Safari/537.36');
     }
 
     get icon() {
         return '/img/connectors/asurascans';
     }
+    
+    async _getPages(chapter) {
+        const excludes = [
+            /panda_gif_large/i,
+            /2021\/04\/page100-10\.jpg/i,
+            /2021\/03\/20-ending-page-\.jpg/i,
+            /ENDING-PAGE/i
+        ];
+        const images = await super._getPages(chapter);
+        return images.filter(link => !excludes.some(rgx => rgx.test(link)));
+    }
+    
 }

--- a/src/web/mjs/connectors/AsuraScansTR.mjs
+++ b/src/web/mjs/connectors/AsuraScansTR.mjs
@@ -16,7 +16,7 @@ export default class AsuraScansTR extends WordPressMangastream {
     get icon() {
         return '/img/connectors/asurascans';
     }
-    
+
     async _getPages(chapter) {
         const excludes = [
             /panda_gif_large/i,
@@ -27,5 +27,5 @@ export default class AsuraScansTR extends WordPressMangastream {
         const images = await super._getPages(chapter);
         return images.filter(link => !excludes.some(rgx => rgx.test(link)));
     }
-    
+
 }


### PR DESCRIPTION
* Asura change url often, so its now a setting
* Had to change AsuraScansTR so it extends Mangastream and not AsuraScans.

Because if you want to set URL as a setting in a connector that is extended by another connector, you end up wiping user settings and bookmarks.

Fixes https://github.com/manga-download/hakuneko/issues/6143