### PR TITLE
CrazyScans: bypass WP Manga Protector

### DIFF
--- a/src/web/mjs/connectors/CrazyScans.mjs
+++ b/src/web/mjs/connectors/CrazyScans.mjs
@@ -9,4 +9,19 @@ export default class CrazyScans extends WordPressMadara {
         this.tags = [ 'webtoon', 'english' ];
         this.url = 'https://mangacultivator.com';
     }
+
+    async _getPages(chapter) {
+        const url = new URL(chapter.id, this.url);
+        const request = new Request(url, this.requestOptions);
+        const script = `
+            new Promise((resolve, reject) => {
+                var imgdata = JSON.parse(CryptoJS.AES.decrypt(chapter_data, wpmangaprotectornonce, {
+                    format: CryptoJSAesJson
+                }).toString(CryptoJS.enc.Utf8));
+                resolve(JSON.parse(imgdata));
+            });
+        `;
+        const data = await Engine.Request.fetchUI(request, script);
+        return data.map(picture => this.createConnectorURI({url : picture, referer : url}));
+    }
 }


### PR DESCRIPTION
https://mangacultivator.com
stol- borrowed the code from the MangaSY (a48270b) connector. Thanks to @MikeZeDev for the help.

It would be nice to know if a template should be created for code maintainability, since this seems to be a madara plugin.