### PR TITLE
Update GoofFansub.mjs

### DIFF
--- a/src/web/mjs/connectors/GoofFansub.mjs
+++ b/src/web/mjs/connectors/GoofFansub.mjs
@@ -7,6 +7,6 @@ export default class GoofFansub extends WordPressMadara {
         super.id = 'gooffansub';
         super.label = 'Goof Fansub';
         this.tags = [ 'hentai', 'high-quality', 'portuguese', 'scanlation' ];
-        this.url = 'https://gooffansub.com.br';
+        this.url = 'https://gooffansub.com';
     }
 }


### PR DESCRIPTION
This site has changed the link: 
Before: https://gooffansub.com.br/
Now: https://gooffansub.com/

Fixes https://github.com/manga-download/hakuneko/issues/6185