### PR TITLE
feat(reader): display connecteur manga page in reader

### DIFF
--- a/src/web/lib/hakuneko/frontend@classic-dark/app.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/app.html
@@ -7,6 +7,7 @@
 <link rel="import" href="jobs.html">
 <link rel="import" href="quotes.html">
 <link rel="import" href="start.html">
+<link rel="import" href="viewmanga.html">
 
 <dom-module id="hakuneko-app">
 
@@ -77,6 +78,11 @@
                 z-index: 0;
                 overflow-x: hidden;
             }
+            hakuneko-manga_presentation {
+                flex: 100;
+                z-index: 0;
+                overflow-x: hidden;
+            }
             #loader {
                 position: fixed;
                 color: var(--app-loading-screen-color);
@@ -130,8 +136,9 @@
             <hakuneko-jobs></hakuneko-jobs>
         </div>
         <div style$="[[ getContentPanelStyle(readerEnabled) ]]" class="content">
-            <hakuneko-start style$="[[ getStartPanelStyle(readerEnabled,chapter) ]]"></hakuneko-start>
-            <hakuneko-pages style$="[[ getPagePanelStyle(readerEnabled,chapter) ]]" selected-chapter="[[ chapter ]]" selected-media="{{ selectedMediaIndex }}"></hakuneko-pages>
+            <hakuneko-start style$="[[ getStartPanelStyle(readerEnabled,manga,chapter) ]]"></hakuneko-start>
+            <hakuneko-viewmanga style$="[[ getMangaPresentationPanelStyle(readerEnabled,manga,chapter) ]]" selected-manga="{{ manga }}"></hakuneko-viewmanga>
+            <hakuneko-pages style$="[[ getPagePanelStyle(readerEnabled,manga,chapter) ]]" selected-chapter="[[ chapter ]]" selected-media="{{ selectedMediaIndex }}"></hakuneko-pages>
         </div>
     </template>
 
@@ -187,15 +194,25 @@
             /**
              *
              */
-            getPagePanelStyle(readerEnabled,chapter) {
-                return ( !readerEnabled || chapter===undefined ? 'display: none;' : '' );
+            getPagePanelStyle(readerEnabled,manga,chapter) {
+                let isDisplayed = readerEnabled && manga!==undefined && chapter!==undefined
+                return ( isDisplayed ? '' : 'display: none;');
             }
 
             /**
              *
              */
-             getStartPanelStyle(readerEnabled,chapter) {
-                return ( chapter!==undefined ? 'display: none;' : '' );
+             getMangaPresentationPanelStyle(readerEnabled,manga,chapter) {
+                let isDisplayed = readerEnabled && manga!==undefined && chapter===undefined
+                return ( isDisplayed ? '' : 'display: none;');
+            }
+
+            /**
+             *
+             */
+             getStartPanelStyle(readerEnabled,manga,chapter) {
+                let isDisplayed = readerEnabled && manga===undefined && chapter===undefined
+                return ( isDisplayed ? '' : 'display: none;');
             }
 
             /**

--- a/src/web/lib/hakuneko/frontend@classic-dark/viewmanga.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/viewmanga.html
@@ -1,0 +1,89 @@
+<link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="../../polymer/lib/elements/dom-if.html">
+<link rel="import" href="theme.html">
+
+<dom-module id="hakuneko-viewmanga">
+    <template>
+        <style include="theme"></style>
+        <style>
+            #container {
+                width: calc(100% - 2em);
+                height: calc(100% - 2em);
+                padding: 1em;
+                background-color: var(--page-control-background-color);
+                overflow-y: scroll;
+                background-size: cover;
+                background-repeat: no-repeat;
+                background-position: left top;
+                font-size: 1.25em;
+                
+                display: flex;
+                flex-direction: column;
+            }
+
+            .show {
+                display: block ;
+            }
+            .hide {
+                display: none;
+            }
+            h1 {
+                font-size:1.5em;
+                margin-top:0;
+                margin-bottom:0;
+                vertical-align:center;
+            }
+            h3 {
+                margin-bottom:0.1em;
+            }
+            .iframe-sytyle { flex-grow: 1; border: none; margin: 0; padding: 0; }
+        </style>
+        <div id="container">
+            <h3>[[ selectedManga.title]] from [[ selectedManga.connector.label ]]</h3>
+            <iframe src="[[ getMangaUrl(selectedManga) ]]" class="iframe-sytyle"></iframe>
+        </div>
+    </template>
+
+    <script>
+        /** @polymerElement */
+        class HakunekoViewManga extends Polymer.Element {
+            /**
+             *
+             */
+            static get is() {
+                return 'hakuneko-viewmanga';
+            }
+
+            /**
+             *
+             */
+             static get properties() {
+                return {
+                    selectedManga: {
+                        type: Object
+                    }
+                };
+            }
+
+            /**
+             *
+             */
+            ready() {
+                super.ready();
+            }
+
+            /**
+             *
+             */
+             getMangaUrl( manga ) {
+                console.log(manga)
+                return manga.connector.url + manga.id
+            }
+
+        }
+
+        window.customElements.define( HakunekoViewManga.is, HakunekoViewManga );
+    </script>
+
+</dom-module>

--- a/src/web/lib/hakuneko/frontend@classic-light/app.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/app.html
@@ -7,6 +7,7 @@
 <link rel="import" href="jobs.html">
 <link rel="import" href="quotes.html">
 <link rel="import" href="start.html">
+<link rel="import" href="viewmanga.html">
 
 <dom-module id="hakuneko-app">
 
@@ -54,7 +55,6 @@
                 z-index: 0;
                 overflow-x: hidden;
             }
-
             hakuneko-menu {
                 flex: 0;
                 -webkit-app-region: drag;
@@ -78,7 +78,11 @@
                 z-index: 0;
                 overflow-x: hidden;
             }
-
+            hakuneko-manga_presentation {
+                flex: 100;
+                z-index: 0;
+                overflow-x: hidden;
+            }
             #loader {
                 position: fixed;
                 color: var(--app-loading-screen-color);
@@ -132,8 +136,9 @@
             <hakuneko-jobs></hakuneko-jobs>
         </div>
         <div style$="[[ getContentPanelStyle(readerEnabled) ]]" class="content">
-            <hakuneko-start style$="[[ getStartPanelStyle(readerEnabled,chapter) ]]"></hakuneko-start>
-            <hakuneko-pages style$="[[ getPagePanelStyle(readerEnabled,chapter) ]]" selected-chapter="[[ chapter ]]" selected-media="{{ selectedMediaIndex }}"></hakuneko-pages>
+            <hakuneko-start style$="[[ getStartPanelStyle(readerEnabled,manga,chapter) ]]"></hakuneko-start>
+            <hakuneko-viewmanga style$="[[ getMangaPresentationPanelStyle(readerEnabled,manga,chapter) ]]" selected-manga="{{ manga }}"></hakuneko-viewmanga>
+            <hakuneko-pages style$="[[ getPagePanelStyle(readerEnabled,manga,chapter) ]]" selected-chapter="[[ chapter ]]" selected-media="{{ selectedMediaIndex }}"></hakuneko-pages>
         </div>
     </template>
 
@@ -189,15 +194,25 @@
             /**
              *
              */
-            getPagePanelStyle(readerEnabled,chapter) {
-                return ( !readerEnabled || chapter===undefined ? 'display: none;' : '' );
+            getPagePanelStyle(readerEnabled,manga,chapter) {
+                let isDisplayed = readerEnabled && manga!==undefined && chapter!==undefined
+                return ( isDisplayed ? '' : 'display: none;');
             }
 
             /**
              *
              */
-             getStartPanelStyle(readerEnabled,chapter) {
-                return ( !readerEnabled || chapter!==undefined ? 'display: none;' : '' );
+             getMangaPresentationPanelStyle(readerEnabled,manga,chapter) {
+                let isDisplayed = readerEnabled && manga!==undefined && chapter===undefined
+                return ( isDisplayed ? '' : 'display: none;');
+            }
+
+            /**
+             *
+             */
+             getStartPanelStyle(readerEnabled,manga,chapter) {
+                let isDisplayed = readerEnabled && manga===undefined && chapter===undefined
+                return ( isDisplayed ? '' : 'display: none;');
             }
 
             /**

--- a/src/web/lib/hakuneko/frontend@classic-light/viewmanga.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/viewmanga.html
@@ -1,0 +1,89 @@
+<link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="../../polymer/lib/elements/dom-if.html">
+<link rel="import" href="theme.html">
+
+<dom-module id="hakuneko-viewmanga">
+    <template>
+        <style include="theme"></style>
+        <style>
+            #container {
+                width: calc(100% - 2em);
+                height: calc(100% - 2em);
+                padding: 1em;
+                background-color: var(--page-control-background-color);
+                overflow-y: scroll;
+                background-size: cover;
+                background-repeat: no-repeat;
+                background-position: left top;
+                font-size: 1.25em;
+                
+                display: flex;
+                flex-direction: column;
+            }
+
+            .show {
+                display: block ;
+            }
+            .hide {
+                display: none;
+            }
+            h1 {
+                font-size:1.5em;
+                margin-top:0;
+                margin-bottom:0;
+                vertical-align:center;
+            }
+            h3 {
+                margin-bottom:0.1em;
+            }
+            .iframe-sytyle { flex-grow: 1; border: solid; margin: 0; padding: 0; }
+        </style>
+        <div id="container">
+            <h3>[[ selectedManga.title]] from [[ selectedManga.connector.label ]]</h3>
+            <iframe src="[[ getMangaUrl(selectedManga) ]]" class="iframe-sytyle"></iframe>
+        </div>
+    </template>
+
+    <script>
+        /** @polymerElement */
+        class HakunekoViewManga extends Polymer.Element {
+            /**
+             *
+             */
+            static get is() {
+                return 'hakuneko-viewmanga';
+            }
+
+            /**
+             *
+             */
+             static get properties() {
+                return {
+                    selectedManga: {
+                        type: Object
+                    }
+                };
+            }
+
+            /**
+             *
+             */
+            ready() {
+                super.ready();
+            }
+
+            /**
+             *
+             */
+             getMangaUrl( manga ) {
+                console.log(manga)
+                return manga.connector.url + manga.id
+            }
+
+        }
+
+        window.customElements.define( HakunekoViewManga.is, HakunekoViewManga );
+    </script>
+
+</dom-module>

--- a/src/web/lib/hakuneko/frontend@classic-light/viewmanga.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/viewmanga.html
@@ -37,7 +37,7 @@
             h3 {
                 margin-bottom:0.1em;
             }
-            .iframe-sytyle { flex-grow: 1; border: solid; margin: 0; padding: 0; }
+            .iframe-sytyle { flex-grow: 1; border: none; margin: 0; padding: 0; }
         </style>
         <div id="container">
             <h3>[[ selectedManga.title]] from [[ selectedManga.connector.label ]]</h3>


### PR DESCRIPTION
I thought it is so helpful to rely on the hakeneko to 'browse' connector web site in reader view when reader is visible + manga is selected + no chapter selected.

As such it is super easy to be done via simple iframe, I created PR to propose this evolution.

Let me know if you feel it may be a good idea and/or if this PR is good enoughor deserved to be worked out further.

Thanks,
S.
