### PR TITLE
feat(downlaod): one click button to download every visible manga

### DIFF
--- a/src/web/lib/hakuneko/frontend@classic-dark/mangas.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/mangas.html
@@ -94,6 +94,9 @@
                         <input id="paste" />
                         <i class="fas fa-fw fa-paste button" on-click="onPasteClick" title="Click to paste manga links from the clipboard (CTRL + V)"></i>
                     </td>
+                    <td width="1">
+                        <i class="fas fa-fw fa-download button" on-click="onDownloadMangaClick" title="Click to download all chapters currently available for all mangas shown in the filtered and sorted list"></i>
+                    </td>
                 </tr>
             </table>
         </div>
@@ -246,6 +249,33 @@
                 } );
                 // trigger update for refresh button style (update started)
                 this.notifyPath( 'selectedConnector.isUpdating' );
+            }
+
+            /**
+             * For all visible manga (filtered), add all their availble chapters currently to the download manager
+             */
+            async onDownloadMangaClick( e ) {
+                let mangas = this['mangaList']
+                let filter = this['mangaPattern']
+                let filteredMangas = mangas
+                if (filter != undefined) {
+                    filteredMangas = mangas.filter((manga) => -1 != manga.title.toLowerCase().indexOf(filter.toLowerCase()))
+                }
+                if ( await confirm( "Download all chapters for the " + filteredMangas.length + " filtered mangas ?" )) {
+                    console.log("Download all chapters for the " + filteredMangas.length + " filtered mangas")
+                    for (var index in filteredMangas) {
+                        let manga = filteredMangas[index]
+                        console.log("Download all available chapters of " + manga.title)
+                        await manga.getChapters( () => {
+                            for (var index in manga.chapterCache) {
+                                let chapter = manga.chapterCache[index]
+                                if (chapter.status === "available") {
+                                    this._downloadManager.addDownload( chapter );
+                                }
+                            }
+                        })
+                    }
+                }
             }
 
             /**

--- a/src/web/lib/hakuneko/frontend@classic-dark/mangas.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/mangas.html
@@ -95,7 +95,7 @@
                         <i class="fas fa-fw fa-paste button" on-click="onPasteClick" title="Click to paste manga links from the clipboard (CTRL + V)"></i>
                     </td>
                     <td width="1">
-                        <i class="fas fa-fw fa-download button" on-click="onDownloadMangaClick" title="Click to download all chapters currently available for all mangas shown in the filtered and sorted list"></i>
+                        <i class="fas fa-fw fa-download button" on-click="onDownloadMangasClick" title="Click to download all chapters currently available for all mangas shown in the filtered and sorted list"></i>
                     </td>
                 </tr>
             </table>
@@ -254,7 +254,7 @@
             /**
              * For all visible manga (filtered), add all their availble chapters currently to the download manager
              */
-            async onDownloadMangaClick( e ) {
+            async onDownloadMangasClick( e ) {
                 let mangas = this['mangaList']
                 let filter = this['mangaPattern']
                 let filteredMangas = mangas

--- a/src/web/lib/hakuneko/frontend@classic-light/mangas.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/mangas.html
@@ -270,7 +270,7 @@
                             for (var index in manga.chapterCache) {
                                 let chapter = manga.chapterCache[index]
                                 if (chapter.status === "available") {
-                                    this._downloadManager.addDownload( chapter );
+                                    Engine._downloadManager.addDownload( chapter );
                                 }
                             }
                         })

--- a/src/web/lib/hakuneko/frontend@classic-light/mangas.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/mangas.html
@@ -94,6 +94,9 @@
                         <input id="paste" />
                         <i class="fas fa-fw fa-paste button" on-click="onPasteClick" title="Click to paste manga links from the clipboard (CTRL + V)"></i>
                     </td>
+                    <td width="1">
+                        <i class="fas fa-fw fa-download button" on-click="onDownloadMangaClick" title="Click to download all chapters currently available for all mangas shown in the filtered and sorted list"></i>
+                    </td>
                 </tr>
             </table>
         </div>
@@ -246,6 +249,33 @@
                 } );
                 // trigger update for refresh button style (update started)
                 this.notifyPath( 'selectedConnector.isUpdating' );
+            }
+
+            /**
+             * For all visible manga (filtered), add all their availble chapters currently to the download manager
+             */
+            async onDownloadMangaClick( e ) {
+                let mangas = this['mangaList']
+                let filter = this['mangaPattern']
+                let filteredMangas = mangas
+                if (filter != undefined) {
+                    filteredMangas = mangas.filter((manga) => -1 != manga.title.toLowerCase().indexOf(filter.toLowerCase()))
+                }
+                if ( await confirm( "Download all chapters for the " + filteredMangas.length + " filtered mangas ?" )) {
+                    console.log("Download all chapters for the " + filteredMangas.length + " filtered mangas")
+                    for (var index in filteredMangas) {
+                        let manga = filteredMangas[index]
+                        console.log("Download all available chapters of " + manga.title)
+                        await manga.getChapters( () => {
+                            for (var index in manga.chapterCache) {
+                                let chapter = manga.chapterCache[index]
+                                if (chapter.status === "available") {
+                                    this._downloadManager.addDownload( chapter );
+                                }
+                            }
+                        })
+                    }
+                }
             }
 
             /**

--- a/src/web/lib/hakuneko/frontend@classic-light/mangas.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/mangas.html
@@ -95,7 +95,7 @@
                         <i class="fas fa-fw fa-paste button" on-click="onPasteClick" title="Click to paste manga links from the clipboard (CTRL + V)"></i>
                     </td>
                     <td width="1">
-                        <i class="fas fa-fw fa-download button" on-click="onDownloadMangaClick" title="Click to download all chapters currently available for all mangas shown in the filtered and sorted list"></i>
+                        <i class="fas fa-fw fa-download button" on-click="onDownloadMangasClick" title="Click to download all chapters currently available for all mangas shown in the filtered and sorted list"></i>
                     </td>
                 </tr>
             </table>
@@ -254,7 +254,7 @@
             /**
              * For all visible manga (filtered), add all their availble chapters currently to the download manager
              */
-            async onDownloadMangaClick( e ) {
+            async onDownloadMangasClick( e ) {
                 let mangas = this['mangaList']
                 let filter = this['mangaPattern']
                 let filteredMangas = mangas


### PR DESCRIPTION
I thought it would be useful to mass download every available chapter for every visible (filtered ) manga.
This helps me a lot to sync locally all my bookmarks or some subset of filtered manga

I don't know if you agree that this could be a valid improvement.
If so, let me know if you feel this PR is enough or if it deserves some evolutions

Thanks,
Serge