### PR TITLE
FIX Tapas: improve manga list

### DIFF
--- a/src/web/mjs/connectors/Tapas.mjs
+++ b/src/web/mjs/connectors/Tapas.mjs
@@ -30,14 +30,19 @@ export default class Tapas extends Connector {
     }
 
     async _getMangasFromPage(page) {
-        let uri = new URL('/comics', this.url);
+        const uri = new URL('/comics', this.url);
         uri.searchParams.set('b', 'ALL');
         uri.searchParams.set('g', 0);
         uri.searchParams.set('pageNumber', page);
         //uri.searchParams.set('pageSize', 20);
-        let request = new Request(uri, this.requestOptions);
-        let data = await this.fetchDOM(request, 'div.section__body ul.content__list li.list__item a.thumb');
-        return data.map(element => {
+        const request = new Request(uri, this.requestOptions);
+        request.headers.set('Accept', 'application/json, text/javascript, */*;');
+
+        const data = await this.fetchJSON(request, this.requestOptions);
+        const dom = new DOMParser().parseFromString(data.data.body, 'text/html');
+        const nodes = [...dom.querySelectorAll('li.list__item a.thumb')];
+
+        return nodes.map(element => {
             return {
                 id: this.getRootRelativeOrAbsoluteLink(element.pathname, this.url),
                 title: element.dataset.tiaraEventMetaSeries.trim()

--- a/src/web/mjs/connectors/Tapas.mjs
+++ b/src/web/mjs/connectors/Tapas.mjs
@@ -40,7 +40,7 @@ export default class Tapas extends Connector {
         return data.map(element => {
             return {
                 id: this.getRootRelativeOrAbsoluteLink(element.pathname, this.url),
-                title: element.querySelector('source').attributes.getNamedItem('alt').value.trim()
+                title: element.dataset.tiaraEventMetaSeries.trim()
             };
         });
     }


### PR DESCRIPTION
* Manga title was like that  : "Tapas genre <title>". There is now a proper title in link dataset.
* Website get next manga list page using json. Do the same for efficiency.  