### PR TITLE
feat(download): add manager and UI for updating bookmarked manga chapters

### DIFF
--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head> 
+<head>
     <meta charset="utf-8">
     <title>HakuNeko</title>
     <link rel="icon" href="./img/logo.png">
@@ -47,13 +47,14 @@
             window.HakuNeko = new HakuNeko(window);
             // TODO: remove backward compatibility alias 'Engine' when all references are set to HakuNeko engine
             window.Engine = window.HakuNeko;
-            
+
             await Engine.initialize();
             // TODO: remove stuff that requires various globals, incl. global HakuNeko engine
             //new HistoryWorker();
             await Engine.Settings.load();
             Engine.BookmarkManager.loadProfile( 'default', undefined );
             Engine.ChaptermarkManager.loadChaptermarks( undefined );
+            Engine.MangaUpdateManager.loadIgnoreUpdateMangas( undefined );
         }
 
         function loadFrontend() {

--- a/src/web/lib/hakuneko/frontend@classic-dark/jobs.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/jobs.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../polymer/lib/elements/dom-if.html">
 <link rel="import" href="theme.html">
 
 <dom-module id="hakuneko-jobs">
@@ -70,6 +71,20 @@
             .hide {
                 display: none;
             }
+            .update-bookmark-chapters {
+                padding-left: 1em;
+            }
+            .far.update-bookmark-chapters-status.active {
+                color: var(--update-bookmark-chapters-disabled-color) !important;
+            }
+            .toggle-bookmark-chapters-update {
+                margin-top: 1.5em !important;
+                font-size: 0.8em !important;
+                margin-left: 2.2em!important;
+            }
+            .toggle-bookmark-chapters-update.active {
+                color: var(--update-bookmark-chapters-stop-color) !important;
+            }
         </style>
         <div class$="list [[ getListClass(popupVisibility) ]]">
             <table cellpadding="0">
@@ -87,6 +102,18 @@
         <div class="bar">
             <div class="expander">
                 <i class$="fas [[ getButtonClass(popupVisibility) ]] button" title="Toggle download list" on-click="toggleJobList"></i>
+            </div>
+            <div class="update-bookmark-chapters" title$="[[ getUpdateBookmarkChaptersTitle(updateBookmarkChaptersStatus) ]]">
+                <span class="button fa-stack fa-xs" on-click="onUpdateBookmarkChaptersClick">
+                    <i class$="far fa-arrow-alt-circle-down fa-stack-2x update-bookmark-chapters-status [[ getUpdateBookmarkChaptersActiveClass(updateBookmarkChaptersStatus) ]]"></i>
+                    <template is="dom-if" if="[[ updateBookmarkChaptersStatus ]]">
+                        <i class="fas fa-fw fa-circle-notch fa-stack-2x fa-spin"></i>
+                        <i class="fas fa-suberlay fa-stop-circle toggle-bookmark-chapters-update active"></i>
+                    </template>
+                </span>
+                <template is="dom-if" if="[[ updateBookmarkChaptersStatus ]]">
+                    <span class="update-bookmark-chapters-status" title$="[[ updateBookmarkChaptersStatus.details ]]">[[ updateBookmarkChaptersStatus.status ]]</span>
+                </template>
             </div>
             <div class="status">[[ jobList.length ]] Download(s)</div>
         </div>
@@ -113,7 +140,14 @@
                         notify: true, // enable upward data flow,
                         //readOnly: true, // prevent downward data flow
                         //observer: 'onSelectedMangaChanged'
-                    }
+                    },
+                    updateBookmarkChaptersStatus: {
+                        type: Object,
+                        value: undefined,
+                        notify: true, // enable upward data flow,
+                        //readOnly: true, // prevent downward data flow
+                        //observer: 'onSelectedMangaChanged'
+                    },
                 };
             }
 
@@ -129,7 +163,11 @@
                 this.jobList = [];
                 // register callbacks for events published by download manager
                 Engine.DownloadManager.addEventListener('updated', this.onDownloadStatusUpdated.bind(this));
+                Engine.MangaUpdateManager.addEventListener('progress', this.onUpdateBookmarkChaptersProgress.bind( this ));
                 this.ipc.on( 'close', this.onClose.bind( this ) );
+                // HACK force evaluating property updateBookmarkChaptersStatus (to properly update title attributes in HTML)
+                this.notifyPath('updateBookmarkChaptersStatus', {});
+                this.notifyPath('updateBookmarkChaptersStatus', undefined);
             }
 
             /**
@@ -198,7 +236,7 @@
             }
 
             /**
-             * 
+             *
              */
             onDownloadStatusUpdated( e ) {
                 let job = e.detail;
@@ -225,6 +263,82 @@
                     if( job.status === 'queued' || job.status === 'downloading' ) {
                         this.push( 'jobList', job );
                     }
+                }
+            }
+
+            getUpdateBookmarkChaptersTitle( updateBookmarkChaptersStatus ) {
+                return (updateBookmarkChaptersStatus ?
+                          updateBookmarkChaptersStatus.canceled ?
+                              'Canceling...' :
+                              'Click to cancel updating chapters for bookmarked mangas' :
+                          'Start updating new chapters for bookmarked mangas'
+                );
+            }
+
+            getUpdateBookmarkChaptersActiveClass( updateBookmarkChaptersStatus ) {
+                return updateBookmarkChaptersStatus ? 'active' : 'inactive';
+            }
+
+            onUpdateBookmarkChaptersClick() {
+
+                if( Engine.MangaUpdateManager.isUpdating ) {
+
+                    Engine.MangaUpdateManager.cancelUpdate();
+                    let msg = 'Canceling ... ' + (this.updateBookmarkChaptersStatus? this.updateBookmarkChaptersStatus.status : '');
+                    let updateStatus = { canceled: true, status: msg, details: msg };
+                    this.set('updateBookmarkChaptersStatus', updateStatus);
+                    return;
+                }
+
+                Engine.MangaUpdateManager.updateAllMangas().then(() => {
+
+                    console.info('downloaded new chapters!');
+
+                } ).catch( error => {
+
+                    console.error('error while trying to download new chapters: ', error);
+
+                });
+            }
+
+            /**
+             *
+             */
+            onUpdateBookmarkChaptersProgress( e ) {
+
+                let data = e.detail;
+                if( data.complete){
+                   this.set('updateBookmarkChaptersStatus', undefined);
+                } else {
+
+                  let updateStatus = {
+                    status: '',
+                    details: '',
+                  };
+
+                  if ( typeof data.current === 'number' ) {
+                      updateStatus.status = data.current + ' / ' + data.total;
+                      let action = data.state === 'step'? 'Updating bookmarked mangas:' : data.state.toUpperCase();
+                      updateStatus.details += action + ' ' + updateStatus.status + '\n';
+                  }
+
+                  updateStatus.details += data.mangaTitle? data.mangaTitle : '';
+                  if( data.connectorTitle ) {
+                    updateStatus.details += '\n' + data.connectorTitle;
+                  }
+
+                  if ( ! updateStatus.details || data.state === 'error') {
+                    updateStatus.details = `[${data.state}] ` + updateStatus.details;
+                  }
+
+                  if( updateStatus.status ) {
+                    updateStatus.status = updateStatus.status.trim();
+                  }
+                  if ( updateStatus.details ) {
+                    updateStatus.details = updateStatus.details.trim();
+                  }
+
+                  this.set('updateBookmarkChaptersStatus', updateStatus);
                 }
             }
 

--- a/src/web/lib/hakuneko/frontend@classic-dark/mangas.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/mangas.html
@@ -61,6 +61,7 @@
                 overflow-x: hidden;
                 text-overflow: ellipsis;
                 cursor: pointer;
+                overflow-y: hidden;
             }
             .manga:hover {
                 background-color: var(--manga-list-highlighted);
@@ -82,6 +83,22 @@
             }
             .footer {
                 flex: 0;
+            }
+            .exclude-in-update, .include-in-update {
+                padding-right: 0.5em;
+                position: relative;
+            }
+            .exclude-in-update, .exclude-in-update .far, .include-in-update, .include-in-update .far {
+                color: unset !important;
+            }
+            .toggle-bookmark-chapters-update {
+                margin-top: 0.66em !important;
+            }
+            .exclude-in-update .fas.exclude-in-update {
+                color: var(--update-bookmark-chapters-exclude-color) !important;
+            }
+            .include-in-update .fas.include-in-update {
+                color: var(--update-bookmark-chapters-include-color) !important;
             }
         </style>
         <div class="header separator">
@@ -122,7 +139,7 @@
             </tr>
         </table>
         <ul class="list" >
-            <template is="dom-if" if="[[ existMangasForValidConnector(selectedConnector, mangaList.length) ]]">                        
+            <template is="dom-if" if="[[ existMangasForValidConnector(selectedConnector, mangaList.length) ]]">
                 <li class="notification">
                     Manga list is loading or empty<br>
                     Click &nbsp;<i class$="fas fa-sync [[ getRefreshClass(selectedConnector.isUpdating) ]] refresh" on-click="onUpdateMangaListClick" title$="Synchronize local manga list with online list from &lt;[[ selectedConnector.label ]]&gt;"></i>&nbsp;
@@ -138,7 +155,13 @@
                 </li>
             </template>
             <template is="dom-repeat" items="[[ mangaList ]]" filter="[[ filterMangas(mangaPattern) ]]" rendered-item-count="{{ mangaFilteredCount }}">
-                <li class$="manga [[ item.status ]] [[ getMangaClass(selectedManga, item.id) ]]" title$="[[ item.title ]]&#10;[[ item.connector.label ]]" on-click="onMangaClicked">[[ item.title ]]</li>
+                <li class$="manga [[ item.status ]] [[ getMangaClass(selectedManga, item.id) ]]" title$="[[ item.title ]]&#10;[[ item.connector.label ]]" on-click="onMangaClicked">
+                  <template is="dom-if" if="[[ processShowUpdateMangaStatus(item) ]]">
+                      <span title$="[[ getUpdateBookmarkChaptersTitle(item._updateBookmarkChaptersStatus) ]]" class$="[[ item._updateBookmarkChaptersStatus ]]" on-click="toggleUpdateBookmarkChapters">
+                          <i class="far fa-arrow-alt-circle-down"></i>
+                          <i class$="fas fa-suberlay [[ item._updateBookmarkChaptersStatus ]] [[ getUpdateBookmarkChaptersClass(item._updateBookmarkChaptersStatus) ]] toggle-bookmark-chapters-update"></i>
+                      </span>
+                </template>[[ item.title ]]</li>
             </template>
         </ul>
         <!-- https://github.com/PolymerElements/iron-list/issues/536 -->
@@ -198,6 +221,7 @@
                 // register callbacks for published events
                 document.addEventListener( EventListener.onMangaStatusChanged, this.onMangaStatusChanged.bind( this ) );
                 Engine.BookmarkManager.addEventListener( 'changed', this.onBookmarksChanged.bind( this ) );
+                Engine.MangaUpdateManager.addEventListener( 'changed', this.onMangaUpdateChanged.bind( this ) );
             }
 
             /**
@@ -210,7 +234,7 @@
                     return;
                 }
                 let statusID = this.$.status.addToQueue( 'Loading manga list (' + connector.label + ')' );
-                // set to undefined when switching manga list prevents a bug in iron-list (high CPU usage) 
+                // set to undefined when switching manga list prevents a bug in iron-list (high CPU usage)
                 this.set( 'mangaList', [] );
                 connector.getMangas( ( error, mangas ) => {
                     // check if executing connector is still the selected connector (visible)
@@ -285,6 +309,41 @@
                 return ( isUpdating ? 'fa-pulse disabled' : '' );
             }
 
+            getUpdatingMangasClass( isRunning ) {
+                return ( isRunning ? 'disabled' : '' );
+            }
+
+            processShowUpdateMangaStatus( manga ) {
+              if ( ! this.selectedConnector || this.selectedConnector.id !== this.bookmarkConnectorID ) {
+                  return false;
+              }
+              manga._updateBookmarkChaptersStatus = Engine.MangaUpdateManager.isIgnoreUpdateManga(manga) ? 'exclude-in-update' : 'include-in-update';
+              return true;
+            }
+
+            getUpdateBookmarkChaptersTitle( updateStatus ) {
+              return updateStatus === 'exclude-in-update' ? 'Click to include when updating bookmarked manga chapters' : 'Click to exclude when updating bookmarked manga chapters';
+            }
+
+            getUpdateBookmarkChaptersClass( updateStatus ) {
+                return updateStatus === 'exclude-in-update' ? 'fa-minus-circle' : 'fa-plus-circle';
+            }
+
+            toggleUpdateBookmarkChapters ( e ) {
+
+              let manga = e.target.parentElement.__dataHost.item;
+
+              let isNotUpate =  manga._updateBookmarkChaptersStatus === 'exclude-in-update';
+              if( isNotUpate ) {
+                  Engine.MangaUpdateManager.deleteIgnoreUpdateManga(manga);
+              } else {
+                  Engine.MangaUpdateManager.addIgnoreUpdateManga(manga);
+              }
+
+              e.preventDefault();
+              e.stopPropagation();
+            }
+
             /**
              *
              */
@@ -301,7 +360,7 @@
             }
 
             /**
-             * 
+             *
              */
             onMangaStatusChanged( e ) {
                 let manga = e.detail;
@@ -327,6 +386,22 @@
             onBookmarksChanged( e ) {
                 if( this.selectedConnector.id === this.bookmarkConnectorID ) {
                     this.onSelectedConnectorChanged( this.selectedConnector )
+                }
+            }
+
+            onMangaUpdateChanged( e ) {
+                if( this.selectedConnector.id === this.bookmarkConnectorID ) {
+                    e.detail.forEach( b => {
+                        let index = this.mangaList.findIndex( ( item ) => {
+                            // mangas may be different objects (synchronizing connector list) but still be equivalent
+                            // => comparing ids instead of comparing the objects directly
+                            return ( item.id === b.key.manga );
+                        });
+                        if( index > -1 ) {
+                            this.processShowUpdateMangaStatus( this.mangaList[index] );
+                            this.notifyPath( 'mangaList.' + index + '._updateBookmarkChaptersStatus');
+                        }
+                    } );
                 }
             }
 

--- a/src/web/lib/hakuneko/frontend@classic-dark/theme.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/theme.html
@@ -61,7 +61,7 @@
                 --menu-credits-background-color: #292b2f; /* Where credits are listed. Next to HakuNeko's Face. */
                 --menu-credits-link-color: #7289da; /* Color of links used in the credits section */
                 --menu-settings-background-color: #2f3136; /* Setting space. Where scroll bar is. */
-                --menu-settings-row-border: 1px solid #40444b; 
+                --menu-settings-row-border: 1px solid #40444b;
 
                 /*
                  * style of connector list
@@ -124,7 +124,7 @@
                 --chapter-button-failed-color: #f04747; /* When chapter does not download */
                 --chapter-marker-active-color: #7289da; /* 'mark as read' marker (bookmark) */
                 --chapter-marker-inactive-color: #7289da; /* 'mark as read' marker (bookmark) */
-                --chapter-marker-removed-color: #f04747; /* No clue */ 
+                --chapter-marker-removed-color: #f04747; /* No clue */
 
                 /*
                  * style of bookmark manager
@@ -162,6 +162,14 @@
                 --page-viewer-title-background-color: rgba(32, 34, 37, 0.95);
                 --page-viewer-title-shadow: 0em 0em 1em rgba(0, 0, 0, 0.5);
                 --page-chapter-title-color: #dcddde;
+
+                /*
+                 * style of update bookmarked manga chapters
+                 */
+                --update-bookmark-chapters-disabled-color: #72767d;
+                --update-bookmark-chapters-stop-color: #f04747;
+                --update-bookmark-chapters-exclude-color: #f04747;
+                --update-bookmark-chapters-include-color: #43b581;
             }
 
             ::-webkit-scrollbar {
@@ -270,7 +278,7 @@
                 color: #7289da;
             }
 
-            
+
 
             /******************************************************************/
             /* Font Awesome 5.8.2 classes for re-use in each shadow DOM scope */

--- a/src/web/lib/hakuneko/frontend@classic-light/jobs.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/jobs.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../polymer/lib/elements/dom-if.html">
 <link rel="import" href="theme.html">
 
 <dom-module id="hakuneko-jobs">
@@ -70,6 +71,20 @@
             .hide {
                 display: none;
             }
+            .update-bookmark-chapters {
+                padding-left: 1em;
+            }
+            .far.update-bookmark-chapters-status.active {
+                color: var(--update-bookmark-chapters-disabled-color) !important;
+            }
+            .toggle-bookmark-chapters-update {
+                margin-top: 1.5em !important;
+                font-size: 0.8em !important;
+                margin-left: 2.2em!important;
+            }
+            .toggle-bookmark-chapters-update.active {
+                color: var(--update-bookmark-chapters-stop-color) !important;
+            }
         </style>
         <div class$="list [[ getListClass(popupVisibility) ]]">
             <table cellpadding="0">
@@ -87,6 +102,18 @@
         <div class="bar">
             <div class="expander">
                 <i class$="fas [[ getButtonClass(popupVisibility) ]] button" title="Toggle download list" on-click="toggleJobList"></i>
+            </div>
+            <div class="update-bookmark-chapters" title$="[[ getUpdateBookmarkChaptersTitle(updateBookmarkChaptersStatus) ]]">
+                <span class="button fa-stack fa-xs" on-click="onUpdateBookmarkChaptersClick">
+                    <i class$="far fa-arrow-alt-circle-down fa-stack-2x update-bookmark-chapters-status [[ getUpdateBookmarkChaptersActiveClass(updateBookmarkChaptersStatus) ]]"></i>
+                    <template is="dom-if" if="[[ updateBookmarkChaptersStatus ]]">
+                        <i class="fas fa-fw fa-circle-notch fa-stack-2x fa-spin"></i>
+                        <i class="fas fa-suberlay fa-stop-circle toggle-bookmark-chapters-update active"></i>
+                    </template>
+                </span>
+                <template is="dom-if" if="[[ updateBookmarkChaptersStatus ]]">
+                    <span class="update-bookmark-chapters-status" title$="[[ updateBookmarkChaptersStatus.details ]]">[[ updateBookmarkChaptersStatus.status ]]</span>
+                </template>
             </div>
             <div class="status">[[ jobList.length ]] Download(s)</div>
         </div>
@@ -113,7 +140,14 @@
                         notify: true, // enable upward data flow,
                         //readOnly: true, // prevent downward data flow
                         //observer: 'onSelectedMangaChanged'
-                    }
+                    },
+                    updateBookmarkChaptersStatus: {
+                        type: Object,
+                        value: undefined,
+                        notify: true, // enable upward data flow,
+                        //readOnly: true, // prevent downward data flow
+                        //observer: 'onSelectedMangaChanged'
+                    },
                 };
             }
 
@@ -129,7 +163,11 @@
                 this.jobList = [];
                 // register callbacks for events published by download manager
                 Engine.DownloadManager.addEventListener('updated', this.onDownloadStatusUpdated.bind(this));
+                Engine.MangaUpdateManager.addEventListener('progress', this.onUpdateBookmarkChaptersProgress.bind( this ));
                 this.ipc.on( 'close', this.onClose.bind( this ) );
+                // HACK force evaluating property updateBookmarkChaptersStatus (to properly update title attributes in HTML)
+                this.notifyPath('updateBookmarkChaptersStatus', {});
+                this.notifyPath('updateBookmarkChaptersStatus', undefined);
             }
 
             /**
@@ -198,7 +236,7 @@
             }
 
             /**
-             * 
+             *
              */
             onDownloadStatusUpdated( e ) {
                 let job = e.detail;
@@ -225,6 +263,82 @@
                     if( job.status === 'queued' || job.status === 'downloading' ) {
                         this.push( 'jobList', job );
                     }
+                }
+            }
+
+            getUpdateBookmarkChaptersTitle( updateBookmarkChaptersStatus ) {
+                return (updateBookmarkChaptersStatus ?
+                          updateBookmarkChaptersStatus.canceled ?
+                              'Canceling...' :
+                              'Click to cancel updating chapters for bookmarked mangas' :
+                          'Start updating new chapters for bookmarked mangas'
+                );
+            }
+
+            getUpdateBookmarkChaptersActiveClass( updateBookmarkChaptersStatus ) {
+                return updateBookmarkChaptersStatus ? 'active' : 'inactive';
+            }
+
+            onUpdateBookmarkChaptersClick() {
+
+                if( Engine.MangaUpdateManager.isUpdating ) {
+
+                    Engine.MangaUpdateManager.cancelUpdate();
+                    let msg = 'Canceling ... ' + (this.updateBookmarkChaptersStatus? this.updateBookmarkChaptersStatus.status : '');
+                    let updateStatus = { canceled: true, status: msg, details: msg };
+                    this.set('updateBookmarkChaptersStatus', updateStatus);
+                    return;
+                }
+
+                Engine.MangaUpdateManager.updateAllMangas().then(() => {
+
+                    console.info('downloaded new chapters!');
+
+                } ).catch( error => {
+
+                    console.error('error while trying to download new chapters: ', error);
+
+                });
+            }
+
+            /**
+             *
+             */
+            onUpdateBookmarkChaptersProgress( e ) {
+
+                let data = e.detail;
+                if( data.complete){
+                   this.set('updateBookmarkChaptersStatus', undefined);
+                } else {
+
+                  let updateStatus = {
+                    status: '',
+                    details: '',
+                  };
+
+                  if ( typeof data.current === 'number' ) {
+                      updateStatus.status = data.current + ' / ' + data.total;
+                      let action = data.state === 'step'? 'Updating bookmarked mangas:' : data.state.toUpperCase();
+                      updateStatus.details += action + ' ' + updateStatus.status + '\n';
+                  }
+
+                  updateStatus.details += data.mangaTitle? data.mangaTitle : '';
+                  if( data.connectorTitle ) {
+                    updateStatus.details += '\n' + data.connectorTitle;
+                  }
+
+                  if ( ! updateStatus.details || data.state === 'error') {
+                    updateStatus.details = `[${data.state}] ` + updateStatus.details;
+                  }
+
+                  if( updateStatus.status ) {
+                    updateStatus.status = updateStatus.status.trim();
+                  }
+                  if ( updateStatus.details ) {
+                    updateStatus.details = updateStatus.details.trim();
+                  }
+
+                  this.set('updateBookmarkChaptersStatus', updateStatus);
                 }
             }
 

--- a/src/web/lib/hakuneko/frontend@classic-light/mangas.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/mangas.html
@@ -61,6 +61,7 @@
                 overflow-x: hidden;
                 text-overflow: ellipsis;
                 cursor: pointer;
+                overflow-y: hidden;
             }
             .manga:hover {
                 background-color: var(--manga-list-highlighted);
@@ -82,6 +83,22 @@
             }
             .footer {
                 flex: 0;
+            }
+            .exclude-in-update, .include-in-update {
+                padding-right: 0.5em;
+                position: relative;
+            }
+            .exclude-in-update, .exclude-in-update .far, .include-in-update, .include-in-update .far {
+                color: unset !important;
+            }
+            .toggle-bookmark-chapters-update {
+                margin-top: 0.66em !important;
+            }
+            .exclude-in-update .fas.exclude-in-update {
+                color: var(--update-bookmark-chapters-exclude-color) !important;
+            }
+            .include-in-update .fas.include-in-update {
+                color: var(--update-bookmark-chapters-include-color) !important;
             }
         </style>
         <div class="header separator">
@@ -122,7 +139,7 @@
             </tr>
         </table>
         <ul class="list" >
-            <template is="dom-if" if="[[ existMangasForValidConnector(selectedConnector, mangaList.length) ]]">                        
+            <template is="dom-if" if="[[ existMangasForValidConnector(selectedConnector, mangaList.length) ]]">
                 <li class="notification">
                     Manga list is loading or empty<br>
                     Click &nbsp;<i class$="fas fa-sync [[ getRefreshClass(selectedConnector.isUpdating) ]] refresh" on-click="onUpdateMangaListClick" title$="Synchronize local manga list with online list from &lt;[[ selectedConnector.label ]]&gt;"></i>&nbsp;
@@ -138,7 +155,13 @@
                 </li>
             </template>
             <template is="dom-repeat" items="[[ mangaList ]]" filter="[[ filterMangas(mangaPattern) ]]" rendered-item-count="{{ mangaFilteredCount }}">
-                <li class$="manga [[ item.status ]] [[ getMangaClass(selectedManga, item.id) ]]" title$="[[ item.title ]]&#10;[[ item.connector.label ]]" on-click="onMangaClicked">[[ item.title ]]</li>
+                <li class$="manga [[ item.status ]] [[ getMangaClass(selectedManga, item.id) ]]" title$="[[ item.title ]]&#10;[[ item.connector.label ]]" on-click="onMangaClicked">
+                  <template is="dom-if" if="[[ processShowUpdateMangaStatus(item) ]]">
+                      <span title$="[[ getUpdateBookmarkChaptersTitle(item._updateBookmarkChaptersStatus) ]]" class$="[[ item._updateBookmarkChaptersStatus ]]" on-click="toggleUpdateBookmarkChapters">
+                          <i class="far fa-arrow-alt-circle-down"></i>
+                          <i class$="fas fa-suberlay [[ item._updateBookmarkChaptersStatus ]] [[ getUpdateBookmarkChaptersClass(item._updateBookmarkChaptersStatus) ]] toggle-bookmark-chapters-update"></i>
+                      </span>
+                </template>[[ item.title ]]</li>
             </template>
         </ul>
         <!-- https://github.com/PolymerElements/iron-list/issues/536 -->
@@ -198,6 +221,7 @@
                 // register callbacks for published events
                 document.addEventListener( EventListener.onMangaStatusChanged, this.onMangaStatusChanged.bind( this ) );
                 Engine.BookmarkManager.addEventListener( 'changed', this.onBookmarksChanged.bind( this ) );
+                Engine.MangaUpdateManager.addEventListener( 'changed', this.onMangaUpdateChanged.bind( this ) );
             }
 
             /**
@@ -210,7 +234,7 @@
                     return;
                 }
                 let statusID = this.$.status.addToQueue( 'Loading manga list (' + connector.label + ')' );
-                // set to undefined when switching manga list prevents a bug in iron-list (high CPU usage) 
+                // set to undefined when switching manga list prevents a bug in iron-list (high CPU usage)
                 this.set( 'mangaList', [] );
                 connector.getMangas( ( error, mangas ) => {
                     // check if executing connector is still the selected connector (visible)
@@ -285,6 +309,41 @@
                 return ( isUpdating ? 'fa-pulse disabled' : '' );
             }
 
+            getUpdatingMangasClass( isRunning ) {
+                return ( isRunning ? 'disabled' : '' );
+            }
+
+            processShowUpdateMangaStatus( manga ) {
+              if ( ! this.selectedConnector || this.selectedConnector.id !== this.bookmarkConnectorID ) {
+                  return false;
+              }
+              manga._updateBookmarkChaptersStatus = Engine.MangaUpdateManager.isIgnoreUpdateManga(manga) ? 'exclude-in-update' : 'include-in-update';
+              return true;
+            }
+
+            getUpdateBookmarkChaptersTitle( updateStatus ) {
+              return updateStatus === 'exclude-in-update' ? 'Click to include when updating bookmarked manga chapters' : 'Click to exclude when updating bookmarked manga chapters';
+            }
+
+            getUpdateBookmarkChaptersClass( updateStatus ) {
+                return updateStatus === 'exclude-in-update' ? 'fa-minus-circle' : 'fa-plus-circle';
+            }
+
+            toggleUpdateBookmarkChapters ( e ) {
+
+              let manga = e.target.parentElement.__dataHost.item;
+
+              let isNotUpate =  manga._updateBookmarkChaptersStatus === 'exclude-in-update';
+              if( isNotUpate ) {
+                  Engine.MangaUpdateManager.deleteIgnoreUpdateManga(manga);
+              } else {
+                  Engine.MangaUpdateManager.addIgnoreUpdateManga(manga);
+              }
+
+              e.preventDefault();
+              e.stopPropagation();
+            }
+
             /**
              *
              */
@@ -301,7 +360,7 @@
             }
 
             /**
-             * 
+             *
              */
             onMangaStatusChanged( e ) {
                 let manga = e.detail;
@@ -327,6 +386,22 @@
             onBookmarksChanged( e ) {
                 if( this.selectedConnector.id === this.bookmarkConnectorID ) {
                     this.onSelectedConnectorChanged( this.selectedConnector )
+                }
+            }
+
+            onMangaUpdateChanged( e ) {
+                if( this.selectedConnector.id === this.bookmarkConnectorID ) {
+                    e.detail.forEach( b => {
+                        let index = this.mangaList.findIndex( ( item ) => {
+                            // mangas may be different objects (synchronizing connector list) but still be equivalent
+                            // => comparing ids instead of comparing the objects directly
+                            return ( item.id === b.key.manga );
+                        });
+                        if( index > -1 ) {
+                            this.processShowUpdateMangaStatus( this.mangaList[index] );
+                            this.notifyPath( 'mangaList.' + index + '._updateBookmarkChaptersStatus');
+                        }
+                    } );
                 }
             }
 

--- a/src/web/lib/hakuneko/frontend@classic-light/theme.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/theme.html
@@ -162,6 +162,14 @@
                 --page-viewer-title-background-color: rgba(255, 255, 255, 0.95);
                 --page-viewer-title-shadow: 0em 0em 1em rgba(0, 0, 0, 0.5);
                 --page-chapter-title-color: #202020;
+
+                /*
+                 * style of update bookmarked manga chapters
+                 */
+                --update-bookmark-chapters-disabled-color: #808080;
+                --update-bookmark-chapters-stop-color: #e08080;
+                --update-bookmark-chapters-exclude-color: #e08080;
+                --update-bookmark-chapters-include-color: #00e000;
             }
 
             input[type="text"], input[type="password"] {

--- a/src/web/mjs/HakuNeko.mjs
+++ b/src/web/mjs/HakuNeko.mjs
@@ -8,6 +8,7 @@ import BookmarkManager from './engine/BookmarkManager.mjs';
 import ChaptermarkManager from './engine/ChaptermarkManager.mjs';
 import Connectors from './engine/Connectors.mjs';
 import DownloadManager from './engine/DownloadManager.mjs';
+import MangaUpdateManager from './engine/MangaUpdateManager.mjs';
 import ComicInfoGenerator from './engine/ComicInfoGenerator.mjs';
 //import HistoryWorker from './engine/HistoryWorker.mjs'
 import Request from './engine/Request.mjs';
@@ -33,6 +34,7 @@ export default class HakuNeko {
         this._connectors = new Connectors(ipc);
         this._storage = new Storage();
         this._bookmarkManager = new BookmarkManager(this._settings, new BookmarkImporter());
+        this._mangaUpdateManager = new MangaUpdateManager(this._settings, this._downloadManager, this._connectors, this._storage, this._bookmarkManager);
         this._comicInfoGenerator = new ComicInfoGenerator();
         this._chaptermarkManager = new ChaptermarkManager(this._settings);
         this._discordPresence = new DiscordPresence(this._settings);
@@ -83,6 +85,10 @@ export default class HakuNeko {
 
     get Enums() {
         return this._enums;
+    }
+
+    get MangaUpdateManager() {
+        return this._mangaUpdateManager;
     }
 
     get Request() {

--- a/src/web/mjs/engine/MangaUpdateManager.mjs
+++ b/src/web/mjs/engine/MangaUpdateManager.mjs
@@ -1,0 +1,390 @@
+import Bookmark from './Bookmark.mjs';
+import Manga from './Manga.mjs';
+import InvalidConnector from '../connectors/system/InvalidConnector.mjs';
+
+const events = {
+    // added: 'added',
+    // removed: 'removed',
+    changed: 'changed',
+    progress: 'progress'
+};
+
+export default class MangaUpdateManager extends EventTarget {
+
+    // TODO: use dependency injection instead of globals for Engine.Connetors, Engine.Storage
+    constructor(settings, downloadManager, connectors, storage, bookmarkManager) {
+        super();
+        this.isUpdating = false;
+        this.ignoreUpdateMangas = []; // list of bookmarks for updating mangas
+        this._updateMangasList = null; // list of Manga objects (will be created from updateMangas)
+        this._settings = settings;
+        this._downloadManager = downloadManager;
+        this._connectors = connectors;
+        this._storage = storage;
+        this._bookmarkManager = bookmarkManager;
+
+        this._settings.addEventListener('saved', this._onSettingsChanged.bind(this));
+    }
+
+    _onSettingsChanged() {
+        // TODO: only save update-chapter if the bookmark directory has changed
+        this._syncIgnoreUpdateMangas(() => this.dispatchEvent( new CustomEvent( events.changed, { detail: this.ignoreUpdateMangas } ) ));
+    }
+
+    /**
+     *
+     */
+    _findIgnoreIndex( bookmarkOrManga ) {
+        if( bookmarkOrManga.key && bookmarkOrManga.key.manga && bookmarkOrManga.key.connector ) {
+            return this.ignoreUpdateMangas.findIndex( bookmark => bookmark.key.manga === bookmarkOrManga.key.manga && bookmark.key.connector === bookmarkOrManga.key.connector );
+        }
+        return this.ignoreUpdateMangas.findIndex( bookmark => bookmark.key.manga === bookmarkOrManga.id && bookmark.key.connector === bookmarkOrManga.connector.id );
+    }
+
+    /**
+     * Try to save the current update-chpaters.
+     * Will reset update-mangas when saving fails.
+     */
+    _syncIgnoreUpdateMangas( callback ) {
+        this._storage.saveBookmarks( 'ignoreupdates', this.ignoreUpdateMangas, 2 )
+            .then( () => {
+                this._updateMangasList = null;
+                // this.dispatchEvent( new CustomEvent( events.changed, { detail: this.ignoreUpdateMangas } ) );
+                if( typeof callback === typeof Function ) {
+                    callback( null );
+                }
+            } )
+            .catch( () => {
+                this.loadIgnoreUpdateMangas( callback );
+            } );
+    }
+
+    /**
+     *
+     */
+    loadIgnoreUpdateMangas( callback ) {
+        this._storage.loadBookmarks( 'ignoreupdates' )
+            .then( data => {
+                try {
+                    if( !data ) {
+                        throw new Error( 'Invalid updateManga list!' );
+                    }
+                    this.ignoreUpdateMangas = data;
+                    this._updateMangasList = null;
+                    this.dispatchEvent( new CustomEvent( events.changed, { detail: this.ignoreUpdateMangas } ) );
+                    if( typeof callback === typeof Function ) {
+                        callback( null );
+                    }
+                } catch( e ) {
+                    console.error( 'Failed to load updateMangas:', e.message );
+                    if( typeof callback === typeof Function ) {
+                        callback( e );
+                    }
+                }
+            } )
+            .catch( error => {
+                if( typeof callback === typeof Function ) {
+                    callback( error );
+                }
+            } );
+    }
+
+    async _loadUpdateMangasList() {
+        return new Promise( (resolve, reject) => {
+            this._getMangaList( (error, mangas) => {
+                if(error) {
+                    return reject(error);
+                }
+                if(!mangas || mangas.length === 0) {
+                    return reject(new Error('Failed updating all mangas: could not find any manga for updating'));
+                }
+                this._updateMangasList = mangas;
+                return resolve();
+            } );
+        } );
+    }
+
+    /**
+     *
+     */
+    _getConnectorByID( id ) {
+        return this._connectors.list.find( connector => {
+            return connector.id === id;
+        } ) || new InvalidConnector( id, `${id} (unavailable)` );
+    }
+
+    /**
+     *
+     */
+    _getMangaList( callback ) {
+        /*
+         * get mangas and check status
+         * use a different approach to determine existence of manga, since it can be expected that
+         * the bookmark list is way shorter than a manga list of a connector => no performance issues expected
+         */
+        let mangas = this._bookmarkManager.bookmarks.filter(bookmark => {
+          let index = this._findIgnoreIndex(bookmark);
+          return index > -1 ? false : true;
+        }).map( bookmark => {
+            let manga = new Manga( this._getConnectorByID( bookmark.key.connector ), bookmark.key.manga, bookmark.title.manga );
+            // determine if manga directory exist on disk
+            this._storage.mangaDirectoryExist( manga )
+                .then( () => {
+                // set existing manga list for related connector (used by manga.updateStatus function)
+                    manga.connector.existingMangas[ this._storage.sanatizePath ( manga.title ) ] = true;
+                    manga.updateStatus();
+                } )
+                .catch( () => { /* directory for bookmark does not yet exist */ } );
+            return manga;
+        });
+        mangas.sort( ( a, b ) => {
+            return a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1;
+        });
+        callback( null, mangas );
+    }
+
+    /**
+     *
+     */
+    isIgnoreUpdateManga( manga ) {
+      return this._findIgnoreIndex(manga) > -1;
+    }
+
+    /**
+     *
+     */
+    addIgnoreUpdateManga( manga ) {
+        if( !manga || ! manga.connector ) {
+            return false;
+        }
+        let index = this._findIgnoreIndex( manga );
+        if( index < 0 ) {
+            let bookmark = new Bookmark( manga );
+            this.ignoreUpdateMangas.push( bookmark );
+            this.ignoreUpdateMangas.sort( this.compareIgnoreUpdateMangas );
+            this._syncIgnoreUpdateMangas( undefined );
+            this.dispatchEvent( new CustomEvent( events.changed, { detail: [bookmark] } ) );
+            // this.dispatchEvent( new CustomEvent( events.added, { detail: bookmark } ) );
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *
+     */
+    deleteIgnoreUpdateManga( bookmarkOrManga ) {
+        let index = this._findIgnoreIndex( bookmarkOrManga );
+        if( index > -1 ) {
+            let bookmark = this.ignoreUpdateMangas[index];
+            this.ignoreUpdateMangas.splice( index, 1 );
+            this._syncIgnoreUpdateMangas( undefined );
+            this.dispatchEvent( new CustomEvent( events.changed, { detail: [bookmark] } ) );
+            // this.dispatchEvent( new CustomEvent( events.removed, { detail: bookmarkOrManga } ) );
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Helper function for sorting
+     */
+    compareIgnoreUpdateMangas( a, b ) {
+        return a.title.manga.toLowerCase() < b.title.manga.toLowerCase() ? -1 : 1;
+    }
+
+    async updateAllMangas() {
+
+        this.isUpdating = true;
+
+        if(!this._updateMangasList) {
+            return this._loadUpdateMangasList()
+                .then(() => this.updateAllMangas())
+                .catch(error => {
+                    console.error('Error while updating Mangas: Failed loading manga list for updates', error);
+
+                    this.isUpdating = false;
+                    this.dispatchEvent( new CustomEvent( events.progress, { detail: {
+                        state: 'error',
+                        complete: true,
+                    } } ) );
+                } );
+        }
+
+        this._canceled = false;
+
+        this.dispatchEvent( new CustomEvent( events.progress, { detail: {
+            state: 'start',
+            complete: false,
+        } } ) );
+
+        try {
+
+            let finished = [];
+            let getFinishedIndex = (theManga) => finished.findIndex( bookmark => bookmark.key.manga === theManga.id && bookmark.key.connector === theManga.connector.id );
+
+            for ( let i = 0; i < this._updateMangasList.length; ++i ) {
+                if( this._canceled ) {
+                    this.isUpdating = false;
+                    this.dispatchEvent( new CustomEvent( events.progress, { detail: {
+                        state: 'cancled',
+                        complete: true,
+                    } } ) );
+                    return;
+                }
+                let manga = this._updateMangasList[i];
+
+                this.dispatchEvent( new CustomEvent( events.progress, { detail: {
+                    state: 'step',
+                    current: i + 1,
+                    total: this._updateMangasList.length,
+                    // item: manga,
+                    mangaTitle: manga.title,
+                    connectorTitle: manga.connector.label,
+                    complete: false,
+                } } ) );
+
+                try {
+
+                    await this._updateChapters( manga );
+
+                    let index = getFinishedIndex( manga );
+                    if(index === -1){
+                      finished.push( new Bookmark(manga) );
+                    }
+
+                } catch( error ) {
+
+                    console.error('Error while updating Mangas: Failed to update manga ', manga, error);
+
+                    this.dispatchEvent( new CustomEvent( events.progress, { detail: {
+                        state: 'error',
+                        current: i + 1,
+                        total: this._updateMangasList? this._updateMangasList.length : 0,
+                        // item: manga,
+                        mangaTitle: manga.title,
+                        connectorTitle: manga.connector.label,
+                        complete: false,
+                    } } ) );
+                }
+
+                try {
+
+                    if( ! this._updateMangasList) {
+                        // list might have been changed / reset while processing the current manga's new chapters:
+                        // -> reload manga-list, if cached list was reset
+                        await this._loadUpdateMangasList();
+
+                        // restore finished/unfinished status in manga list:
+                        // (1) do sort according to already finished status:
+                        this._updateMangasList.sort( ( a, b ) => {
+                            let finA = getFinishedIndex( a );
+                            let finB = getFinishedIndex( b );
+                            if ( finA === -1 && finB !== -1){
+                                return 1;
+                            } else if ( finA !== -1 && finB === -1){
+                                return -1;
+                            }
+                            return a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1;
+                        });
+                        // (2) find last finished index for continuing update process:
+                        for(let j=0, size = this._updateMangasList.length; i < size; ++j){
+                            let curr = this._updateMangasList[j];
+                            let finCurr = getFinishedIndex( curr );
+                            if(finCurr === -1){
+                                i = j - 1;
+                                break;
+                            }
+                        }
+                    }
+
+                } catch( error ) {
+
+                    console.error('Error while updating Mangas: Failed loading manga list for updates', error);
+
+                    this.isUpdating = false;
+                    this.dispatchEvent( new CustomEvent( events.progress, { detail: {
+                        state: 'error',
+                        complete: true,
+                    } } ) );
+
+                    return; // EARLY EXIT //
+                }
+
+            }
+
+            this.isUpdating = false;
+            this.dispatchEvent( new CustomEvent( events.progress, { detail: {
+                state: 'finished',
+                complete: true,
+            } } ) );
+
+        } catch( error ) {
+
+            // "catch all" to ensure isUpdating is always set correctly
+
+            console.error('Error while updating Mangas: Unexpected error occurred while updating new chapters', error);
+
+            this.isUpdating = false;
+            this.dispatchEvent( new CustomEvent( events.progress, { detail: {
+                state: 'error',
+                complete: true,
+            } } ) );
+
+            return; // EARLY EXIT //
+        }
+    }
+
+    _updateChapters( manga ) {
+
+        if( this._canceled ) {
+            return Promise.resolve();
+        }
+
+        return new Promise( (resolve, reject) => manga.getChapters( ( error, chapters ) => {
+
+            if ( error ) {
+                console.error('Error while updating Mangas: Failed to get chapters for manga ' + manga.title + '(' + manga.connector.label + ')', error);
+                return reject(error);
+            }
+
+            if( this._canceled ) {
+                return resolve();
+            }
+
+            for ( let i = 0, size = chapters.length; i < size; ++i ) {
+
+                if( this._canceled ) {
+                    return resolve();
+                }
+
+                // console.log('  processing chapter "'+chapters[i].title+'"['+chapters[i].status+'] (['+chapters[i].manga.connector.label+'].'+chapters[i].manga.title+') for update...');
+                this._enqueueOrIgnoreChapter( chapters[i] );
+            }
+
+            resolve();
+        } ) );
+
+    }
+
+    _enqueueOrIgnoreChapter( chapter ) {
+        switch ( chapter.status ) {
+            case 'failed': // intentional fallthrough
+            case 'available':
+                this._downloadManager.addDownload( chapter );
+                return true;
+
+            // ignore chapters if status is:
+            case 'unavailable': // intentional fallthrough
+            case 'offline': // intentional fallthrough
+            case 'completed': // intentional fallthrough
+            default:
+                return false;
+        }
+    }
+
+    cancelUpdate() {
+        this._canceled = true;
+        this.isUpdating = false;
+    }
+}


### PR DESCRIPTION
add functionality for checking & queuing new chapters in __Bookmark__ list/connector

> NOTE this feature is similar to the PR #6224 but restricted to the Bookmark list _(plus some other features)_

main features:
 * start / cancel updating bookmarked manga chapters
 * include / exclude bookmarked mangas from update
 * show status / progress when checking for new manga chapters

The start / cancel button (and the progress information) is added at the bottom next to download-list button.

_(also note that _canceling_ in this context means to stop checking for new chapters -- chapters that were already queued for downloading would not be effected)_

The Bookmark list has additional include/exclude buttons for each bookmarked manga (for including/excluding during the update).

The current implementation always waits until `Manga.getChapters()` is finished, before checking the next manga -- this could be changed, e.g. to not waiting at all or only waiting if `Manga.getChapters()` is active for the the same Connector.
