### PR TITLE
Fix PixivComics: correct header

### DIFF
--- a/src/web/mjs/connectors/PixivComics.mjs
+++ b/src/web/mjs/connectors/PixivComics.mjs
@@ -14,7 +14,7 @@ export default class PixivComics extends Connector {
         };
         this.apiURL = 'https://comic.pixiv.net/api/app/';
         this.requestOptions.headers.set('x-referer', this.url);
-        this.requestOptions.headers.set('x-requested-with', this.url);
+        this.requestOptions.headers.set('x-requested-with', 'pixivcomic');
     }
 
     async _getMangaFromURI(uri) {


### PR DESCRIPTION
not an urgent fix cause everything works.
Its just to make it closer to what the website does.