### PR TITLE
Change ReadComicOnline display name to match its actual name

### DIFF
--- a/src/web/mjs/connectors/KissComic.mjs
+++ b/src/web/mjs/connectors/KissComic.mjs
@@ -6,7 +6,7 @@ export default class KissComic extends Connector {
     constructor() {
         super();
         super.id = 'kisscomic';
-        super.label = 'KissComic (ReadComicOnline)';
+        super.label = 'ReadComicOnline.li (KissComic)';
         this.tags = [ 'comic', 'english' ];
         this.url = 'https://readcomiconline.li';
     }

--- a/src/web/mjs/connectors/ReadComicsOnline.mjs
+++ b/src/web/mjs/connectors/ReadComicsOnline.mjs
@@ -11,7 +11,7 @@ export default class ReadComicsOnline extends MangaReaderCMS {
     constructor() {
         super();
         super.id = 'readcomicsonline';
-        super.label = 'Read Comics Online';
+        super.label = 'ReadComicsOnline.ru';
         this.tags = [ 'comic', 'english' ];
         this.url = 'https://readcomicsonline.ru';
         this.links = {


### PR DESCRIPTION
This changes the label (assuming that [this](https://github.com/manga-download/hakuneko/blob/93c21813d872987128a7b3017073263e4e832b00/src/web/mjs/engine/Connectors.mjs#L53) defines the sort order) for ReadComicOnline so it shows up under **R** for **R**eadComicOnline instead of **K** for **K**notBeenCalledThatForYearsNow.  Maybe this'll end the cycle that seems to play out roughly every month or so where someone can't find it in the list and asks for it to be supported.

It also changes the label for the similarly-named but very different site ReadComic**s**Online so the difference is more obvious than one letter S hiding in the middle.  Domain suffixes are less than ideal, since they can change (the imprint on RCO._li_ identifies as RCO._to_), but there doesn't seem to be anything else on that site to identify it.