### PR TITLE
FIx MangaNato : fix domain regex

### DIFF
--- a/src/web/mjs/connectors/MangaNel.mjs
+++ b/src/web/mjs/connectors/MangaNel.mjs
@@ -33,7 +33,7 @@ export default class MangaNel extends Connector {
 
     canHandleURI(uri) {
         // Test: https://regex101.com/r/aPR3zy/3/tests
-        return /^(chap|read)?manganato\.com$/.test(uri.hostname);
+        return /^(chap|read)?manganato\.(com|to)$/.test(uri.hostname);
     }
 
     async _getMangaFromURI(uri) {


### PR DESCRIPTION
Fixes https://github.com/manga-download/hakuneko/issues/6617

chapmanganato.to / readmanganato.to (no more .com? )