### PR TITLE
Lezhin : change manga list endpoint & language values

### DIFF
--- a/src/web/mjs/connectors/LezhinEN.mjs
+++ b/src/web/mjs/connectors/LezhinEN.mjs
@@ -12,7 +12,7 @@ export default class LezhinEN extends Lezhin {
             login: this.url + '/login#email'
         };
         this.requestOptions.headers.set( 'x-cookie', 'x-lz-locale=en_US' );
-        this.requestOptions.headers.set( 'x-lz-locale', 'en_US' );
+        this.requestOptions.headers.set( 'x-lz-locale', 'en-US' );
         this.locale = 'en-US';
     }
 }

--- a/src/web/mjs/connectors/LezhinJA.mjs
+++ b/src/web/mjs/connectors/LezhinJA.mjs
@@ -12,7 +12,7 @@ export default class LezhinJA extends Lezhin {
             login: this.url + '/login#email'
         };
         this.requestOptions.headers.set( 'x-cookie', 'x-lz-locale=ja_JP' );
-        this.requestOptions.headers.set( 'x-lz-locale', 'ja_JP' );
+        this.requestOptions.headers.set( 'x-lz-locale', 'ja-JP' );
         this.locale = 'ja-JP';
     }
 }

--- a/src/web/mjs/connectors/LezhinKO.mjs
+++ b/src/web/mjs/connectors/LezhinKO.mjs
@@ -12,7 +12,7 @@ export default class LezhinKO extends Lezhin {
             login: this.url + '/login#email'
         };
         this.requestOptions.headers.set( 'x-cookie', 'x-lz-locale=ko_KR' );
-        this.requestOptions.headers.set( 'x-lz-locale', 'ko_KR' );
+        this.requestOptions.headers.set( 'x-lz-locale', 'ko-KR' );
         this.locale = 'ko-KR';
     }
 }

--- a/src/web/mjs/connectors/templates/Lezhin.mjs
+++ b/src/web/mjs/connectors/templates/Lezhin.mjs
@@ -101,14 +101,15 @@ export default class Lezhin extends Connector {
     }
 
     async _getMangasFromPage(page) {
-        const uri = new URL('/lz-api/v2/comics', this.apiURL);
+        const uri = new URL('/lz-api/v2/contents', this.apiURL);
         uri.searchParams.set('menu', 'general');
         uri.searchParams.set('limit', this.mangasPerPage);
         uri.searchParams.set('offset', page * this.mangasPerPage);
         uri.searchParams.set('order', 'popular');
-        uri.searchParams.set('adult_kind', 'all');
-
         const request = new Request(uri, this.requestOptions);
+
+        request.headers.set('X-LZ-Adult', '0');
+        request.headers.set('X-LZ-AllowAdult', 'true');
         const data = await this.fetchJSON(request);
         return data.data.map( manga => {
             return {


### PR DESCRIPTION
Quite an easy fix : 
* Langage value in api must be like "en-US" and not "en_US"
* Manga list endpoint changed from "comics" to "contents", and adult values are now http headers and not GET values.
* Fixes https://github.com/manga-download/hakuneko/issues/6686