### PR TITLE
Fix performance issues while rendering large lists

### DIFF
--- a/src/web/lib/hakuneko/frontend@classic-dark/mangas.html
+++ b/src/web/lib/hakuneko/frontend@classic-dark/mangas.html
@@ -137,7 +137,7 @@
                     and go to the network tab
                 </li>
             </template>
-            <template is="dom-repeat" items="[[ mangaList ]]" filter="[[ filterMangas(mangaPattern) ]]" rendered-item-count="{{ mangaFilteredCount }}">
+            <template is="dom-repeat" items="[[ mangaList ]]" filter="[[ filterMangas(mangaPattern) ]]" rendered-item-count="{{ mangaFilteredCount }}" initial-count="500">
                 <li class$="manga [[ item.status ]] [[ getMangaClass(selectedManga, item.id) ]]" title$="[[ item.title ]]&#10;[[ item.connector.label ]]" on-click="onMangaClicked">[[ item.title ]]</li>
             </template>
         </ul>

--- a/src/web/lib/hakuneko/frontend@classic-light/mangas.html
+++ b/src/web/lib/hakuneko/frontend@classic-light/mangas.html
@@ -137,7 +137,7 @@
                     and go to the network tab
                 </li>
             </template>
-            <template is="dom-repeat" items="[[ mangaList ]]" filter="[[ filterMangas(mangaPattern) ]]" rendered-item-count="{{ mangaFilteredCount }}">
+            <template is="dom-repeat" items="[[ mangaList ]]" filter="[[ filterMangas(mangaPattern) ]]" rendered-item-count="{{ mangaFilteredCount }}" initial-count="500">
                 <li class$="manga [[ item.status ]] [[ getMangaClass(selectedManga, item.id) ]]" title$="[[ item.title ]]&#10;[[ item.connector.label ]]" on-click="onMangaClicked">[[ item.title ]]</li>
             </template>
         </ul>


### PR DESCRIPTION
Set initialCount for dom-repeat element that can hold many items

The manga list can hold up to hundreds of thousands of items or more, and this causes major performance issues during rendering (see Polymer/polymer#2537). The solution is to ask <dom-repeat> to render a limited subset of the items per frame instead of all in one frame, as explained in https://polymer-library.polymer-project.org/3.0/docs/devguide/templates#large-list-perf.