### PR TITLE
FIx KomikAV: domain typo

### DIFF
--- a/src/web/mjs/connectors/KomikAV.mjs
+++ b/src/web/mjs/connectors/KomikAV.mjs
@@ -7,7 +7,7 @@ export default class KomikAV extends WordPressMangastream {
         super.id = 'komikav';
         super.label = 'APKomik';
         this.tags = [ 'manga', 'indonesian' ];
-        this.url = 'https://apkomic.cc';
+        this.url = 'https://apkomik.cc';
         this.path = '/manga/list-mode/';
     }
 }


### PR DESCRIPTION
Fixes https://github.com/manga-download/hakuneko/issues/6879