### PR TITLE
chore: consistently enforce line endings 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# file is at the root of the project
+root = true
+
+# enforce lf line ending
+[*]
+end_of_line = lf
+
+# crlf for files that are incompatible with lf
+[*.bat]
+end_of_line = crlf
+
+[*.cmd]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Check all text files into the repo with the LF line ending.
+* text=auto eol=lf
+
+# Check out lf incompatible files with the CRLF line ending.
+*.cmd eol=crlf
+*.bat eol=crlf


### PR DESCRIPTION
Consistently enforce line endings regardless of what operating system is used.
Good article about this: https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git

If you think this is unnecessary, just close the pr. Though it wouldn't hurt to adopt this.

Existing files won't be changed (unless you specifically use a git cmd like `git add --renormalize .`).