### PR TITLE
chore: create devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Node.js",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bookworm",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm install",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"extensions": [
+				"kangping.protobuf",
+				"github.vscode-github-actions",
+				"usernamehw.errorlens",
+				"wayou.vscode-todo-highlight"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
Create [devcontainer](https://containers.dev/) config.

It's used by gh's codespaces, VSCodes's devcontainer extensions and allows you to move your dev env to your local or an external docker host.

The config won't need any maintenance until Debian 12 (bookworm) or Node.js version 20 is deprecated, which would be in 2026. While the VSCode extensions might break or become incompatible, it will only affect the extension.

vscode:
- tutorial: [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers), [Dev Containers tutorial](https://code.visualstudio.com/docs/devcontainers/tutorial)
- extension: [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)

I added a few VSCode extensions for convenience. Please tell me if I should remove any (or all) of them:
- [protobuf](https://marketplace.visualstudio.com/items?itemName=kangping.protobuf) (proto language support)
- [GitHub Actions](https://marketplace.visualstudio.com/items?itemName=github.vscode-github-actions) (config, etc support. added it since the repo has gh action configs)
- [Error Lens](https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens) (highlights & shows errors)
- [TODO Highlight](https://marketplace.visualstudio.com/items?itemName=wayou.vscode-todo-highlight) (highlights `TODO:`)