### PR TITLE
SushiScans : update manga path

### DIFF
--- a/src/web/mjs/connectors/SushiScans.mjs
+++ b/src/web/mjs/connectors/SushiScans.mjs
@@ -9,7 +9,7 @@ export default class SushiScans extends WordPressMangastream {
         super.label = 'Sushi Scans';
         this.tags = [ 'manga', 'french' ];
         this.url = 'https://sushiscan.net';
-        this.path = '/manga/list-mode/';
+        this.path = '/catalogue/list-mode/';
         this.requestOptions.headers.set('x-referer', this.url);
     }
 


### PR DESCRIPTION
Just the link that changed it's '/catalogue/list-mode/' instead of '/manga/list-mode/'