### PR TITLE
fix title fetch and image fetch in hitomi.la

### DIFF
--- a/src/web/mjs/connectors/Hitomi.mjs
+++ b/src/web/mjs/connectors/Hitomi.mjs
@@ -13,11 +13,21 @@ export default class Hitomi extends Connector {
     }
 
     async _getMangaFromURI(uri) {
-        let request = new Request(uri, this.requestOptions);
-        let data = await this.fetchDOM(request, 'div.gallery h1 a', 3);
-        let id = uri.pathname.match(/(\d+)\.html$/)[1];
-        let title = data[0].text.trim();
-        return new Manga(this, id, title);
+        const request = new Request(uri, this.requestOptions);
+        const script = `
+            new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    try {
+                        resolve(galleryinfo.title);
+                    } catch(error) {
+                        reject(error);
+                    }
+                }, 1000);
+            });
+        `;
+        const title = await Engine.Request.fetchUI(request, script);
+        const id = uri.pathname.match(/(\d+)\.html$/)[1];
+        return new Manga(this, id, title.trim());
     }
 
     async _getMangas() {
@@ -38,7 +48,7 @@ export default class Hitomi extends Connector {
             new Promise((resolve, reject) => {
                 setTimeout(() => {
                     try {
-                        let images = galleryinfo.files.map(info => url_from_url_from_hash(galleryinfo.id, info));
+                        let images = galleryinfo.files.map(image => url_from_url_from_hash(galleryinfo.id, image, 'webp', undefined, 'a'));
                         resolve(images);
                     } catch(error) {
                         reject(error);


### PR DESCRIPTION
Two observations:
- for some reason a direct DOM fetch from the request to get the title does not work (anymore). This is not related to the fetch but rather to the requested page itself, as the title element to be just gone (reproducable in curl). The suspicion I have is that there might be some javascript run afterwards that populates the title instead, hence resorting to js injection to get the title directly (unfortunate, but better than completely broken).
- the source code on the site for fetching images has changed, updating to be consistent to what is on the site.