### PR TITLE
Yanmaga: Fix error handling and restore _getMangaFromURI

### DIFF
--- a/src/web/mjs/connectors/Yanmaga.mjs
+++ b/src/web/mjs/connectors/Yanmaga.mjs
@@ -58,9 +58,6 @@ export default class Yanmaga extends SpeedBinb {
     }
 
     _getPageList( manga, chapter, callback ) {
-        if (chapter.id.includes('/sign-up')) {
-            throw new Error(`You need to login to see ${chapter.title}`);
-        }
         const uri = new URL(chapter.id, this.url);
         fetch(uri)
             .then(response => {

--- a/src/web/mjs/connectors/Yanmaga.mjs
+++ b/src/web/mjs/connectors/Yanmaga.mjs
@@ -48,21 +48,24 @@ export default class Yanmaga extends SpeedBinb {
         return Engine.Request.fetchUI(request, chapterScript, 10000);
     }
 
-    _getPageList( manga, chapter, callback ) {
-        if (chapter.id.includes('/sign-up')) {
-            throw new Error(`You need to login to see ${chapter.title}`);
+    async _getPageList(manga, chapter, callback) {
+        try {
+            if (chapter.id.includes('/sign-up')) {
+                throw new Error(`You need to login to see ${chapter.title}`);
+            }
+            const uri = new URL(chapter.id, this.url);
+            const response = await fetch(uri);
+            if (response.redirected) {
+                const newurl = new URL(response.url);
+                return super._getPageList(manga, { id: newurl.pathname + newurl.search }, callback);
+            }
+            if (!uri.searchParams.get('cid')) {
+                throw new Error(`You need to login to see ${chapter.title}`);
+            }
+            return super._getPageList(manga, chapter, callback);
+        } catch (error) {
+            console.error(error, chapter);
+            callback(error, undefined);
         }
-        const uri = new URL(chapter.id, this.url);
-        fetch(uri)
-            .then(response => {
-                if (response.redirected) {
-                    const newurl = new URL(response.url);
-                    return super._getPageList(manga, { id: newurl.pathname+newurl.search }, callback);
-                }
-                if (!uri.searchParams.get('cid')) {
-                    throw new Error(`You need to login to see ${chapter.title}`);
-                }
-                return super._getPageList(manga, chapter, callback);
-            });
     }
 }

--- a/src/web/mjs/connectors/Yanmaga.mjs
+++ b/src/web/mjs/connectors/Yanmaga.mjs
@@ -57,24 +57,25 @@ export default class Yanmaga extends SpeedBinb {
         return Engine.Request.fetchUI(request, chapterScript, 10000);
     }
 
-    async _getPageList(manga, chapter, callback) {
-        try {
-            if (chapter.id.includes('/sign-up')) {
-                throw new Error(`You need to login to see ${chapter.title}`);
-            }
-            const uri = new URL(chapter.id, this.url);
-            const response = await fetch(uri);
-            if (response.redirected) {
-                const newurl = new URL(response.url);
-                return super._getPageList(manga, { id: newurl.pathname + newurl.search }, callback);
-            }
-            if (!uri.searchParams.get('cid')) {
-                throw new Error(`You need to login to see ${chapter.title}`);
-            }
-            return super._getPageList(manga, chapter, callback);
-        } catch (error) {
-            console.error(error, chapter);
-            callback(error, undefined);
+    _getPageList( manga, chapter, callback ) {
+        if (chapter.id.includes('/sign-up')) {
+            throw new Error(`You need to login to see ${chapter.title}`);
         }
+        const uri = new URL(chapter.id, this.url);
+        fetch(uri)
+            .then(response => {
+                if (response.redirected) {
+                    const newurl = new URL(response.url);
+                    return super._getPageList(manga, { id: newurl.pathname+newurl.search }, callback);
+                }
+                if (!uri.searchParams.get('cid')) {
+                    throw new Error(`You need to login to see ${chapter.title}`);
+                }
+                return super._getPageList(manga, chapter, callback);
+            })
+            .catch(error => {
+                console.error(error, chapter);
+                callback(error, undefined);
+            });
     }
 }

--- a/src/web/mjs/connectors/Yanmaga.mjs
+++ b/src/web/mjs/connectors/Yanmaga.mjs
@@ -1,4 +1,5 @@
 import SpeedBinb from './templates/SpeedBinb.mjs';
+import Manga from '../engine/Manga.mjs';
 
 export default class Yanmaga extends SpeedBinb {
     constructor() {
@@ -10,6 +11,14 @@ export default class Yanmaga extends SpeedBinb {
         this.links = {
             login: 'https://yanmaga.jp/customers/sign-in'
         };
+    }
+
+    async _getMangaFromURI(uri) {
+        const request = new Request(uri);
+        const [data] = await this.fetchDOM(request, '.detailv2-outline-title');
+        const id = uri.pathname;
+        const title = data.textContent.trim();
+        return new Manga(this, id, title);
     }
 
     async _getMangas() {


### PR DESCRIPTION
If a user tries to download a chapter that requires rental or login, an exception is thrown in the `_getPageList` function.
However, because the exception is not handled, there is no indication in the UI that the download has failed.
I have fixed this by handling the exception.

Also, since switching from `ComiciViewer` to `SpeedBinb` (https://github.com/manga-download/hakuneko/commit/e93e7c1744ee7713a1024aff6271dc3a4fe95a44), copy and paste support seems to be broken.
I have restored the `_getMangaFromURI` function from the following part.
https://github.com/manga-download/hakuneko/blob/5f8979d8453a7570c5f01b797681811f71c630fd/src/web/mjs/connectors/Yanmaga.mjs#L23-L29

**To Reproduce**

1. URL of manga: https://yanmaga.jp/comics/%E3%81%BF%E3%82%87%E3%83%BC%E3%81%A1%E3%82%83%E3%82%93%E5%85%88%E7%94%9F%E3%81%AF%E3%81%8B%E3%81%8F%E8%AA%9E%E3%82%8A%E3%81%8D
2. When you paste the URL, the manga title is displayed as `Manga #24B9`. The correct title is `みょーちゃん先生はかく語りき`.
3. Name of chapter:
    - Chapter that requires rental: `第７８限　シンメトリーフェティシズム`
    - Chapter that requires login: `第４限　バズ・レッスン！`
5. Copy any relevant error message that appears in a popup or (advanced) within the console (press F12)
    ```
   Uncaught (in promise) Error: You need to login to see 第７８限　シンメトリーフェティシズム
       at Yanmaga.mjs:63
   (anonymous) @ Yanmaga.mjs:63
   Promise.then (async)
   _getPageList @ Yanmaga.mjs:57
   (anonymous) @ Chapter.mjs:111
   Promise.then (async)
   getPages @ Chapter.mjs:109
   downloadPages @ DownloadJob.mjs:72
   processQueue @ DownloadManager.mjs:49
   
   Uncaught (in promise) Error: You need to login to see 第４限　バズ・レッスン！
       at Yanmaga.mjs:63
   (anonymous) @ Yanmaga.mjs:63
   Promise.then (async)
   _getPageList @ Yanmaga.mjs:57
   (anonymous) @ Chapter.mjs:111
   Promise.then (async)
   getPages @ Chapter.mjs:109
   downloadPages @ DownloadJob.mjs:72
   processQueue @ DownloadManager.mjs:49
   ```