### PR TITLE
MangaFire : add referer

### DIFF
--- a/src/web/mjs/connectors/MangaFire.mjs
+++ b/src/web/mjs/connectors/MangaFire.mjs
@@ -161,7 +161,7 @@ export default class MangaFire extends Connector {
         const e = imageArray[2];
         const canvas = document.createElement('CANVAS');
         const ctx = canvas.getContext('2d');
-        const image = await this._loadImage("data:"+ mimebuffer.mimeType+";base64," + mimebuffer.data.toString("base64"));
+        const image = await this._loadImage('data:'+ mimebuffer.mimeType+';base64,' + mimebuffer.data.toString('base64'));
 
         canvas.width = image.width;
         canvas.height = image.height;


### PR DESCRIPTION
Closes https://github.com/manga-download/hakuneko/issues/7847
Closes https://github.com/manga-download/hakuneko/issues/7843

In case of scrambling, we loaded image data directly as image.src= url. But there is no way to use the correct referrer using that method. I prefer to avoid using createObjectUrl()