### PR TITLE
fix 1-connector-website-not-working.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-connector-website-not-working.yml
+++ b/.github/ISSUE_TEMPLATE/1-connector-website-not-working.yml
@@ -36,7 +36,6 @@ body:
       options:
         - label: Yes, the problem cannot be reproduced with Nightly Build
           required: false
-          default: true
   - type: dropdown
     attributes:
       label: What kind of issue are you encountering


### PR DESCRIPTION
body[4]: options[0]: default is not a permitted attribute
body[4]: default is not a permitted attribute