### PR TITLE
MangaPLanet : fix chapters title

### DIFF
--- a/src/web/mjs/connectors/MangaPlanet.mjs
+++ b/src/web/mjs/connectors/MangaPlanet.mjs
@@ -68,7 +68,7 @@ export default class MangaPlanet extends SpeedBinb {
                 }
                 chapters.push({
                     id: url,
-                    title: title + chapter.querySelector('span').innerText.trim()
+                    title: title + chapter.querySelector('h3 span').innerText.trim()
                 });
             }
         }


### PR DESCRIPTION
Corrected Chapter title parsing for MangaPlanet connector.

Closes https://github.com/manga-download/hakuneko/issues/8118