### PR TITLE
Fix broken MDN links

### DIFF
--- a/src/web/mjs/engine/Blacklist.mjs
+++ b/src/web/mjs/engine/Blacklist.mjs
@@ -1,7 +1,7 @@
 export default class Blacklist {
     /*
      * https://developer.chrome.com/extensions/match_patterns
-     * https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Match_patterns
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns
      */
     constructor() {
         this.patterns = [


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates the old Add-ons documentation URLs to the new format.

**Changes:**
- Old URL: `https://developer.mozilla.org/en-US/Add-ons/...`
- New URL: `https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/...`

---

*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*