### PR TITLE
Fix MangaKakalotFun: offset-based manga list pagination and pages format

### DIFF
--- a/src/web/mjs/connectors/MangaHub.mjs
+++ b/src/web/mjs/connectors/MangaHub.mjs
@@ -43,20 +43,19 @@ export default class MangaHub extends Connector {
     }
 
     async _getMangas() {
-        const gql = `{
-            search(x: ${this.path}, q: "", genre: "all", mod: ALPHABET, limit: 99999) {
-                rows {
-                    id, slug, title
+        const mangaList = [];
+        for (let offset = 0, run = true; run; offset += 50) {
+            const gql = `{
+                search(x: ${this.path}, q: "", genre: "all", mod: ALPHABET, limit: 50, offset: ${offset}) {
+                    rows {
+                        id, slug, title
+                    }
                 }
-            }
-        }`;
-        const data = await this.fetchGraphQL(this.apiURL, undefined, gql, undefined);
-        return data.search.rows.map(manga => {
-            return {
-                id: manga.slug, // manga.id
-                title: manga.title
-            };
-        });
+            }`;
+            const { search: { rows } } = await this.fetchGraphQL(this.apiURL, undefined, gql, undefined);
+            rows.length > 0 ? mangaList.push(...rows.map(manga => ({ id: manga.slug, title: manga.title }))) : run = false;
+        }
+        return mangaList;
     }
 
     async _getChapters(manga) {
@@ -84,9 +83,11 @@ export default class MangaHub extends Connector {
                 pages
             }
         }`;
-        let data = await this.fetchGraphQL(this.apiURL, undefined, gql, undefined);
-        data = JSON.parse(data.chapter.pages);
-        return data.i.map(page => this.createConnectorURI(new URL(data.p + page, this.cdnURL).href));
+        const { chapter: { pages } } = await this.fetchGraphQL(this.apiURL, undefined, gql, undefined);
+        const data = JSON.parse(pages);
+        const images = data.i ? data.i : Object.values(data);
+        const prefix = data.p || '';
+        return images.map(page => this.createConnectorURI(new URL(prefix + page, this.cdnURL).href));
     }
 
     async _handleConnectorURI(payload) {

--- a/src/web/mjs/connectors/MangaKakalotFun.mjs
+++ b/src/web/mjs/connectors/MangaKakalotFun.mjs
@@ -10,40 +10,5 @@ export default class MangaKakalotFun extends MangaHub {
         this.url = 'https://mangakakalot.fun';
 
         this.path = 'mn01';
-        this.mangaPerPage = 30;
-    }
-
-    async _getMangas() {
-        const mangaList = [];
-        for (let offset = 0; ; offset += this.mangaPerPage) {
-            const gql = `{
-                search(x: ${this.path}, q: "", genre: "all", mod: ALPHABET, count: true, offset: ${offset}) {
-                    rows {
-                        id, slug, title
-                    }
-                    count
-                }
-            }`;
-            const data = await this.fetchGraphQL(this.apiURL, undefined, gql, undefined);
-            const rows = data.search.rows;
-            mangaList.push(...rows.map(manga => ({ id: manga.slug, title: manga.title })));
-            if (mangaList.length >= data.search.count || rows.length < this.mangaPerPage) {
-                break;
-            }
-        }
-        return mangaList;
-    }
-
-    async _getPages(chapter) {
-        const gql = `{
-            chapter(x: ${this.path}, slug: "${chapter.manga.id}", number: ${chapter.id}) {
-                pages
-            }
-        }`;
-        let data = await this.fetchGraphQL(this.apiURL, undefined, gql, undefined);
-        data = JSON.parse(data.chapter.pages);
-        const prefix = data.p || '';
-        const images = data.i || Object.values(data);
-        return images.map(page => this.createConnectorURI(new URL(prefix + page, this.cdnURL).href));
     }
 }

--- a/src/web/mjs/connectors/MangaKakalotFun.mjs
+++ b/src/web/mjs/connectors/MangaKakalotFun.mjs
@@ -1,19 +1,49 @@
 import MangaHub from './MangaHub.mjs';
 
-/**
- *
- */
 export default class MangaKakalotFun extends MangaHub {
 
-    /**
-     *
-     */
     constructor() {
         super();
         super.id = 'mangakakalotfun';
         super.label = 'MangaKakalotFun';
+        this.tags = [ 'manga', 'webtoon', 'english' ];
         this.url = 'https://mangakakalot.fun';
 
         this.path = 'mn01';
+        this.mangaPerPage = 30;
+    }
+
+    async _getMangas() {
+        const mangaList = [];
+        for (let offset = 0; ; offset += this.mangaPerPage) {
+            const gql = `{
+                search(x: ${this.path}, q: "", genre: "all", mod: ALPHABET, count: true, offset: ${offset}) {
+                    rows {
+                        id, slug, title
+                    }
+                    count
+                }
+            }`;
+            const data = await this.fetchGraphQL(this.apiURL, undefined, gql, undefined);
+            const rows = data.search.rows;
+            mangaList.push(...rows.map(manga => ({ id: manga.slug, title: manga.title })));
+            if (mangaList.length >= data.search.count || rows.length < this.mangaPerPage) {
+                break;
+            }
+        }
+        return mangaList;
+    }
+
+    async _getPages(chapter) {
+        const gql = `{
+            chapter(x: ${this.path}, slug: "${chapter.manga.id}", number: ${chapter.id}) {
+                pages
+            }
+        }`;
+        let data = await this.fetchGraphQL(this.apiURL, undefined, gql, undefined);
+        data = JSON.parse(data.chapter.pages);
+        const prefix = data.p || '';
+        const images = data.i || Object.values(data);
+        return images.map(page => this.createConnectorURI(new URL(prefix + page, this.cdnURL).href));
     }
 }


### PR DESCRIPTION
Fixes two issues with the MangaKakalotFun connector.

The parent class uses `limit: 99999`, but the site's API was updated, deprecating it. it uses offset-based pagination (count: true, offset: N) with 30 items per page. only the first batch of results was being returned. connector now overrides _getMangas to paginate through all results using the count field from the response.

MangaHub._getPages only handled the `{p, i}` pages format. site's client also falls back to Object.values(data) when the i key is not there. connector now overrides inherited method to handle both formats

both fixes were tested, and linted, and derived from the website's javascript.
